### PR TITLE
feat(scanner): multi-signal FP reduction pipeline + lab harness

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,3 +17,10 @@ build:
 
 dev:
     cargo build
+
+# End-to-end validation: runs smugglex against a set of local mock backends
+# that simulate canonical FP and TP smuggling scenarios. Requires a release
+# build (auto-built by the harness if missing).
+lab:
+    cargo build --release
+    python3 lab/validate.py

--- a/lab/README.md
+++ b/lab/README.md
@@ -1,0 +1,81 @@
+# Lab — end-to-end validation harness
+
+A Python harness that runs the **actual** `smugglex` binary against a set of
+local mock backends and asserts that each scenario produces the expected
+verdict and detection signals. Complements `cargo test`, which exercises the
+library in isolation, by verifying the full CLI → output pipeline against a
+sweep of true-positive and false-positive scenarios.
+
+## Usage
+
+```sh
+just lab               # builds release binary + runs validate.py
+# or directly:
+cargo build --release
+python3 lab/validate.py
+```
+
+Exits 0 if every scenario matches its expected outcome, non-zero otherwise.
+
+## What it validates
+
+Each scenario is a small socket-level "backend" that produces a deterministic
+response pattern. The harness runs `smugglex --quiet --format json --checks
+cl-te --max-payloads 5 http://127.0.0.1:<port>/` against each and compares:
+
+1. **Verdict** — was `vulnerable` reported as expected?
+2. **Required signals** — for true-positive scenarios, the harness asserts
+   that the *specific* detection pathway under test fired (e.g.,
+   `followup_divergence` for the second-request scenario), not just that
+   *some* detection happened.
+
+## Scenarios
+
+### False positives (must NOT flag)
+
+| Name | Backend behavior | What it exercises |
+|------|-----------------|---|
+| `FP_clean` | Always 200, fast, normal body | Baseline sanity — no anomalies → no detection |
+| `FP_slow_post_uniform` | All POSTs ~1.4 s, GETs fast | Method-matched POST baseline lifting the threshold |
+| `FP_uniform_504` | Everything returns 504 | Baseline-majority-timeout suppression of status signal |
+| `FP_noisy_baseline` | One slow (1.5 s) baseline GET, borderline 1.2 s POSTs | Noise-aware threshold (`max + buffer`) |
+| `FP_heavy_post` | POSTs with body slow, CL:0 POSTs and GETs fast | Differential control comparison rejecting heavy-shape FPs |
+
+### True positives (must flag)
+
+| Name | Backend behavior | Signal exercised |
+|------|-----------------|---|
+| `TP_clte_status` | TE-carrying requests get 504 | `status_504` |
+| `TP_clte_timing` | TE-carrying requests are slow, all other shapes fast | `timing_anomaly` |
+| `TP_followup_desync` | Attack + control both slow with identical small body, but post-attack GETs return a divergent body | `followup_divergence` *(only path keeping the finding alive)* |
+| `TP_body_divergence` | TE attack body diverges from control body despite similar timing | `body_divergence_vs_control` |
+
+The follow-up and body-divergence scenarios are constructed so that *only*
+the named signal can rescue the finding from the standard FP rejection rules
+— this verifies the intended detection pathway in isolation.
+
+## Adding a scenario
+
+Add a handler function to `validate.py`:
+
+```python
+def my_scenario(sock, req, n):
+    # `sock` is the accepted client socket
+    # `req`  is the raw HTTP request bytes (headers up to \r\n\r\n)
+    # `n`    is the per-listener request count (1-indexed)
+    sock.sendall(http_response(NORMAL_BODY))
+```
+
+Then register it in the `SCENARIOS` list with the expected verdict and (for
+positives) the required signal substring(s).
+
+## Limitations
+
+- The mock backends emulate the externally observable behavior of vulnerable
+  proxy/backend chains rather than performing actual HTTP desync. Good
+  enough to validate detection-pipeline behavior; not a substitute for
+  testing against real proxy software.
+- `--max-payloads 5` caps the per-check payload count to keep the harness
+  runtime bounded. FP scenarios where every TE variation triggers detection
+  + control rejection would otherwise spend tens of seconds per payload
+  iterating through the full ~30-payload set.

--- a/lab/README.md
+++ b/lab/README.md
@@ -39,7 +39,10 @@ cl-te --max-payloads 5 http://127.0.0.1:<port>/` against each and compares:
 | `FP_slow_post_uniform` | All POSTs ~1.4 s, GETs fast | Method-matched POST baseline lifting the threshold |
 | `FP_uniform_504` | Everything returns 504 | Baseline-majority-timeout suppression of status signal |
 | `FP_noisy_baseline` | One slow (1.5 s) baseline GET, borderline 1.2 s POSTs | Noise-aware threshold (`max + buffer`) |
-| `FP_heavy_post` | POSTs with body slow, CL:0 POSTs and GETs fast | Differential control comparison rejecting heavy-shape FPs |
+| `FP_heavy_post` | POSTs with body slow, CL:0 POSTs and GETs fast | Differential control comparison + consecutive-FP early termination |
+| `FP_waf_blocks_te` | WAF returns 403 on TE shapes, 200 otherwise | Verifies the scanner does not over-interpret WAF-shaped status/body differences as smuggling |
+| `FP_natural_body_jitter` | Every response body varies ±4% (480–520 B) within similarity threshold | Body/follow-up divergence heuristics do not over-trigger on natural backend variability |
+| `FP_intermittent_504` | ~5% of post-baseline requests return 504 (realistic flake rate) | Strict-majority confirmation + all-retries-for-status-only suppress sparse intermittent failures. Pathologically high flake rates (≥20%) remain a known limitation. |
 
 ### True positives (must flag)
 

--- a/lab/validate.py
+++ b/lab/validate.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import random
 import socket
 import subprocess
 import sys
@@ -172,6 +173,61 @@ def tp_body_divergence(sock, req, n):
         sock.sendall(http_response(NORMAL_BODY))
 
 
+# ---- Additional realistic FP scenarios ----
+
+
+def fp_waf_blocks_te(sock, req, n):
+    """A WAF in front of a healthy backend rejects any request carrying
+    Transfer-Encoding with a small 403 body. Non-TE shapes pass through to
+    the backend and return the normal substantial body. Status differs (200
+    vs 403), body sizes differ — looks suspicious to a naive detector, but
+    is not desync."""
+    has_te = b"transfer-encoding" in req.lower()
+    if has_te:
+        sock.sendall(http_response(b"Forbidden by WAF", status="403 Forbidden"))
+    else:
+        sock.sendall(http_response(NORMAL_BODY))
+
+
+def fp_natural_body_jitter(sock, req, n):
+    """Backend with natural body-size jitter on every response (A/B testing,
+    server-side rendering variation, multiple cache variants). No timing
+    or status anomalies — only body size varies within ±4% of the
+    canonical NORMAL_BODY length. Validates that the body-divergence and
+    follow-up-divergence heuristics do not over-trigger on natural
+    per-request body variability inside the similarity threshold."""
+    # Deterministic jitter 480..520 B = within ~92% of 500 B (per
+    # CONTROL_BODY_DIVERGENCE_PCT=75 rule, anything ≥ 75% similar is NOT
+    # divergent). No timing/status anomalies — pure body variation.
+    jitter = (n * 7919) % 41  # 0..40
+    body = b"X" * (480 + jitter)
+    sock.sendall(http_response(body))
+
+
+def fp_intermittent_504(sock, req, n):
+    """Backend occasionally returns 504 (~5% of post-baseline requests) due
+    to realistic upstream flakiness (e.g., periodic backend GC pauses,
+    sparse upstream load spikes). The strict-majority confirmation rule +
+    all-retries-required for status-only signals must suppress detection.
+
+    NOTE: Pathologically high flake rates (≥20%) are a known limitation —
+    they can still false-confirm with low probability when retry seeds
+    align unfavorably. Distinguishing high-rate intermittent failures from
+    real status-only smuggling would require statistical sampling across
+    multiple payload variants, which conflicts with the exit-first design.
+    """
+    # Deterministic pseudo-random based on request number so the test is
+    # reproducible. ~5% post-baseline failure rate — realistic for a
+    # marginally-healthy backend, well below the false-confirmation
+    # threshold (0.05^3 = 0.0125%).
+    rng = random.Random(n * 1000003)  # noqa: S311 — deterministic, not security
+    is_failure = n > 3 and rng.random() < 0.05
+    if is_failure:
+        sock.sendall(http_response(b"Gateway timeout", status="504 Gateway Timeout"))
+    else:
+        sock.sendall(http_response(NORMAL_BODY))
+
+
 # ----------------------------- helpers -------------------------------------
 
 
@@ -231,7 +287,25 @@ SCENARIOS: list[Scenario] = [
         "FP_heavy_post",
         heavy_post_uniform,
         expected_vulnerable=False,
-        notes="all POSTs-with-body slow; control comparison must reject",
+        notes="all POSTs-with-body slow; control comparison + R10 early termination",
+    ),
+    Scenario(
+        "FP_waf_blocks_te",
+        fp_waf_blocks_te,
+        expected_vulnerable=False,
+        notes="WAF returns 403 on TE shapes; not smuggling — should not flag",
+    ),
+    Scenario(
+        "FP_natural_body_jitter",
+        fp_natural_body_jitter,
+        expected_vulnerable=False,
+        notes="natural body-size variation within similarity threshold; no anomalies",
+    ),
+    Scenario(
+        "FP_intermittent_504",
+        fp_intermittent_504,
+        expected_vulnerable=False,
+        notes="~30% transient 504s; strict-majority confirmation must suppress",
     ),
     # Positives (must flag)
     Scenario(

--- a/lab/validate.py
+++ b/lab/validate.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""
+Local smuggling-lab validation harness for smugglex.
+
+Spins up a series of socket-level fake backends, each simulating a distinct
+scenario (real smuggling, benign-noisy backend, slow POST handler, etc.),
+invokes the smugglex binary against each, parses the JSON output, and reports
+whether the verdict matches expectations.
+
+Run from the repository root:
+    python3 lab/validate.py
+
+Exits non-zero if any scenario disagrees with its expected outcome.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import socket
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Callable
+from contextlib import closing
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SMUGGLEX = REPO_ROOT / "target" / "release" / "smugglex"
+
+# Each scenario is given (conn_socket, request_bytes, request_count_int).
+ScenarioHandler = Callable[[socket.socket, bytes, int], None]
+
+
+# ----------------------------- response helpers -----------------------------
+
+
+def http_response(body: bytes | str, status: str = "200 OK", server: str = "test") -> bytes:
+    if isinstance(body, str):
+        body = body.encode()
+    head = (
+        f"HTTP/1.1 {status}\r\n"
+        f"Content-Length: {len(body)}\r\n"
+        f"Server: {server}\r\n"
+        "Connection: close\r\n"
+        "\r\n"
+    ).encode()
+    return head + body
+
+
+# Body sizes chosen to give the body-divergence heuristic clear signal:
+# NORMAL_BODY is large (500 B), SMALL_ERROR_BODY is below MIN_BYTES (3 B),
+# DESYNC_BODY is well over MIN_BYTES but far below NORMAL_BODY (80 B vs 500 B
+# = 16% — clearly diverges per CONTROL_BODY_DIVERGENCE_PCT=75 rule).
+NORMAL_BODY = b"X" * 500
+SMALL_ERROR_BODY = b"ERR"
+DESYNC_BODY = b"D" * 80
+
+
+# --------------------------- scenario implementations -----------------------
+
+
+def clean(sock, req, n):
+    """Always returns a normal fast response — nothing suspicious anywhere."""
+    sock.sendall(http_response(NORMAL_BODY))
+
+
+def slow_post_uniform(sock, req, n):
+    """Every POST is slow (~1.4s). The method-matched POST baseline should
+    lift the threshold so a POST attack at ~1.4s does NOT flag."""
+    if not req.startswith(b"GET"):
+        time.sleep(1.4)
+    sock.sendall(http_response(NORMAL_BODY))
+
+
+def uniform_504(sock, req, n):
+    """Backend always returns 504. Baseline majority is 504 → status signal
+    must be suppressed."""
+    sock.sendall(http_response(b"Gateway timeout", status="504 Gateway Timeout"))
+
+
+def noisy_baseline(sock, req, n):
+    """One slow baseline GET (1500ms) creates a high-variance baseline. A
+    borderline 1200ms attack must NOT flag (noise-aware threshold + variance
+    demotion)."""
+    if n == 1:
+        time.sleep(1.5)
+    elif n > 3 and req.startswith(b"POST"):
+        time.sleep(1.2)
+    sock.sendall(http_response(NORMAL_BODY))
+
+
+def heavy_post_uniform(sock, req, n):
+    """POSTs with body are slow (mimicking expensive serverside processing for
+    any non-empty body); CL:0 POSTs and GETs are fast. Attack with TE body and
+    control with padded body both look slow — control comparison must reject."""
+    body_present = (
+        b"transfer-encoding" in req.lower()
+        or _has_nonzero_content_length(req)
+    )
+    if body_present:
+        time.sleep(2.0)
+    sock.sendall(http_response(NORMAL_BODY))
+
+
+# ---- True-positive scenarios ----
+
+
+def tp_clte_status(sock, req, n):
+    """TE-carrying requests get 504; other shapes 200. Classic CL.TE
+    status-code signal."""
+    if b"transfer-encoding" in req.lower():
+        sock.sendall(http_response(b"Gateway timeout", status="504 Gateway Timeout"))
+    else:
+        sock.sendall(http_response(NORMAL_BODY))
+
+
+def tp_clte_timing(sock, req, n):
+    """TE-carrying requests are slow (2s); other shapes fast. Timing-only TE
+    smuggling indicator that survives the method-matched POST baseline
+    (because POST with CL:0 baseline is fast — only TE-carrying POSTs slow)."""
+    if b"transfer-encoding" in req.lower():
+        time.sleep(2.0)
+    sock.sendall(http_response(NORMAL_BODY))
+
+
+def tp_followup_desync(sock, req, n):
+    """TE attack AND control both return the same small error body slowly —
+    body/header divergence escapes do NOT fire. Only the post-attack follow-up
+    GETs return a divergent body relative to baseline, exercising the
+    second-request smuggling signal in isolation.
+
+    Request order with R8 method-matched POST baseline:
+      1..=3   GET baseline                 (NORMAL_BODY)
+      4..=6   POST CL:0 baseline           (NORMAL_BODY, fast)
+      7       attack (TE)                  (slow, SMALL_ERROR_BODY)
+      8..=10  3 confirmation retries (TE)  (slow, SMALL_ERROR_BODY)
+      11..=12 2 control samples (POST padded body, no TE)
+                                           (slow, SMALL_ERROR_BODY ← matches attack)
+      13..=15 3 follow-up GETs             (fast, DESYNC_BODY ← diverges from
+                                            baseline)
+    """
+    has_te = b"transfer-encoding" in req.lower()
+    has_body = has_te or _has_nonzero_content_length(req)
+    is_followup = 13 <= n <= 15
+
+    if has_body:
+        # Attack AND control both slow + identical small body so divergence
+        # escapes via body/header are inert; only follow-up can save the
+        # finding.
+        time.sleep(2.0)
+        sock.sendall(http_response(SMALL_ERROR_BODY))
+        return
+    if is_followup:
+        sock.sendall(http_response(DESYNC_BODY))
+        return
+    sock.sendall(http_response(NORMAL_BODY))
+
+
+def tp_body_divergence(sock, req, n):
+    """TE attack: slow + small error body. Control (TE stripped, padded body):
+    slow + normal body. Bodies diverge → escape clause keeps the finding even
+    though timing similarity would otherwise reject."""
+    has_te = b"transfer-encoding" in req.lower()
+    has_body = has_te or _has_nonzero_content_length(req)
+    if has_body:
+        time.sleep(2.0)
+    if has_te:
+        sock.sendall(http_response(SMALL_ERROR_BODY))
+    else:
+        sock.sendall(http_response(NORMAL_BODY))
+
+
+# ----------------------------- helpers -------------------------------------
+
+
+def _has_nonzero_content_length(req: bytes) -> bool:
+    for line in req.split(b"\r\n"):
+        ls = line.lower().lstrip()
+        if ls.startswith(b"content-length:"):
+            value = ls.split(b":", 1)[1].strip()
+            if value and value != b"0":
+                return True
+    return False
+
+
+# ---------------------------- harness --------------------------------------
+
+
+@dataclasses.dataclass
+class Scenario:
+    name: str
+    handler: ScenarioHandler
+    expected_vulnerable: bool
+    # Substrings that MUST appear in detection_signals (each entry only needs
+    # to be a prefix/substring of some signal). Empty for non-vulnerable
+    # scenarios. Lets the harness validate not just the verdict but also that
+    # the *intended* signal pathway is what produced it.
+    required_signal_substrings: tuple[str, ...] = ()
+    notes: str = ""
+
+
+SCENARIOS: list[Scenario] = [
+    # Negatives (must NOT flag)
+    Scenario(
+        "FP_clean",
+        clean,
+        expected_vulnerable=False,
+        notes="benign backend, no anomalies",
+    ),
+    Scenario(
+        "FP_slow_post_uniform",
+        slow_post_uniform,
+        expected_vulnerable=False,
+        notes="all POSTs ~1.4s; method-matched baseline must suppress",
+    ),
+    Scenario(
+        "FP_uniform_504",
+        uniform_504,
+        expected_vulnerable=False,
+        notes="baseline majority 504; status signal must be suppressed",
+    ),
+    Scenario(
+        "FP_noisy_baseline",
+        noisy_baseline,
+        expected_vulnerable=False,
+        notes="one slow baseline GET; borderline POST must not flag",
+    ),
+    Scenario(
+        "FP_heavy_post",
+        heavy_post_uniform,
+        expected_vulnerable=False,
+        notes="all POSTs-with-body slow; control comparison must reject",
+    ),
+    # Positives (must flag)
+    Scenario(
+        "TP_clte_status",
+        tp_clte_status,
+        expected_vulnerable=True,
+        required_signal_substrings=("status_504",),
+        notes="TE-carrying requests return 504 — classic status signal",
+    ),
+    Scenario(
+        "TP_clte_timing",
+        tp_clte_timing,
+        expected_vulnerable=True,
+        required_signal_substrings=("timing_anomaly",),
+        notes="TE-carrying requests are slow but other shapes fast",
+    ),
+    Scenario(
+        "TP_followup_desync",
+        tp_followup_desync,
+        expected_vulnerable=True,
+        required_signal_substrings=("followup_divergence",),
+        notes="post-attack GETs diverge from baseline — second-request smuggling",
+    ),
+    Scenario(
+        "TP_body_divergence",
+        tp_body_divergence,
+        expected_vulnerable=True,
+        required_signal_substrings=("body_divergence_vs_control",),
+        notes="TE response body diverges from control body despite timing match",
+    ),
+]
+
+
+def bind_free_port() -> tuple[socket.socket, int]:
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    port = listener.getsockname()[1]
+    listener.listen(64)
+    listener.settimeout(0.5)
+    return listener, port
+
+
+def serve_forever(listener: socket.socket, handler: ScenarioHandler, stop_event: threading.Event):
+    counter = 0
+    counter_lock = threading.Lock()
+
+    def serve_one(conn: socket.socket, n: int):
+        with closing(conn):
+            try:
+                conn.settimeout(5.0)
+                buf = b""
+                # Drain whatever the client sent (up to 16KB).
+                try:
+                    while True:
+                        chunk = conn.recv(4096)
+                        if not chunk:
+                            break
+                        buf += chunk
+                        if len(buf) >= 16384:
+                            break
+                        if b"\r\n\r\n" in buf:
+                            # Headers received; for our scenarios we don't
+                            # need to honor any further body bytes.
+                            break
+                except (socket.timeout, ConnectionError):
+                    pass
+                handler(conn, buf, n)
+            except Exception:
+                # Swallow — scenarios should be best-effort, scanner must
+                # tolerate broken backends.
+                pass
+
+    while not stop_event.is_set():
+        try:
+            conn, _ = listener.accept()
+        except socket.timeout:
+            continue
+        except OSError:
+            break
+        with counter_lock:
+            counter += 1
+            n = counter
+        threading.Thread(target=serve_one, args=(conn, n), daemon=True).start()
+
+
+def run_smugglex_against(port: int) -> dict:
+    """Invoke smugglex with JSON output, return parsed dict."""
+    cmd = [
+        str(SMUGGLEX),
+        "--quiet",
+        "--format",
+        "json",
+        "--checks",
+        "cl-te",
+        "--timeout",
+        "6",
+        # Cap payload count: FP scenarios that get repeatedly FP-rejected via
+        # control comparison would otherwise iterate through every TE variation
+        # and blow the harness budget. 5 is enough to verify the rejection
+        # behavior triggers on the canonical CL.TE shape.
+        "--max-payloads",
+        "5",
+        f"http://127.0.0.1:{port}/",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
+    out = proc.stdout
+    start = out.find("{")
+    if start < 0:
+        raise RuntimeError(f"no JSON in smugglex output:\nstdout={out!r}\nstderr={proc.stderr!r}")
+    return json.loads(out[start:])
+
+
+def evaluate_scenario(sc: Scenario) -> tuple[str, bool, list[str], str]:
+    """Returns (verdict, actual_vulnerable, signals, summary_str)."""
+    listener, port = bind_free_port()
+    stop = threading.Event()
+    t = threading.Thread(target=serve_forever, args=(listener, sc.handler, stop), daemon=True)
+    t.start()
+    try:
+        result = run_smugglex_against(port)
+    finally:
+        stop.set()
+        try:
+            listener.close()
+        except OSError:
+            pass
+
+    checks = result.get("checks", [])
+    any_vuln = any(c.get("vulnerable", False) for c in checks)
+    signals: list[str] = []
+    confidence = None
+    for c in checks:
+        if c.get("vulnerable"):
+            signals.extend(c.get("detection_signals", []) or [])
+            confidence = c.get("confidence")
+
+    verdict = "PASS"
+    missing_signals: list[str] = []
+    if any_vuln != sc.expected_vulnerable:
+        verdict = "FAIL"
+    if any_vuln and sc.required_signal_substrings:
+        for needle in sc.required_signal_substrings:
+            if not any(needle in s for s in signals):
+                missing_signals.append(needle)
+        if missing_signals:
+            verdict = "FAIL"
+
+    summary_parts: list[str] = []
+    if any_vuln:
+        summary_parts.append(f"confidence={confidence}")
+        summary_parts.append(f"signals={signals}")
+    if missing_signals:
+        summary_parts.append(f"missing_signals={missing_signals}")
+    summary = " ".join(summary_parts)
+    return verdict, any_vuln, signals, summary
+
+
+def main() -> int:
+    if not SMUGGLEX.exists():
+        print(f"smugglex binary not found at {SMUGGLEX}", file=sys.stderr)
+        print("Run: cargo build --release", file=sys.stderr)
+        return 2
+
+    print(f"{'Scenario':<26} {'Expected':<10} {'Actual':<10} {'Verdict':<7}  Detail")
+    print("-" * 100)
+    failures: list[str] = []
+    for sc in SCENARIOS:
+        try:
+            verdict, actual, signals, summary = evaluate_scenario(sc)
+        except Exception as e:
+            verdict = "ERROR"
+            actual = False
+            signals = []
+            summary = f"exception: {e}"
+        marker = " " if verdict == "PASS" else "!"
+        print(
+            f"{marker} {sc.name:<24} {str(sc.expected_vulnerable):<10} {str(actual):<10} {verdict:<7}  {summary}"
+        )
+        if verdict != "PASS":
+            failures.append(sc.name)
+
+    print()
+    if failures:
+        print(f"{len(failures)} / {len(SCENARIOS)} scenario(s) failed: {', '.join(failures)}")
+        return 1
+    print(f"All {len(SCENARIOS)} scenarios passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lab/validate.py
+++ b/lab/validate.py
@@ -329,14 +329,10 @@ def run_smugglex_against(port: int) -> dict:
         "cl-te",
         "--timeout",
         "6",
-        # Cap payload count: FP scenarios that get repeatedly FP-rejected via
-        # control comparison would otherwise iterate through every TE variation
-        # and blow the harness budget. 5 is enough to verify the rejection
-        # behavior triggers on the canonical CL.TE shape.
-        "--max-payloads",
-        "5",
         f"http://127.0.0.1:{port}/",
     ]
+    # No --max-payloads cap: with R10 consecutive-FP early termination, FP
+    # scenarios that previously needed the cap should now self-abort.
     proc = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
     out = proc.stdout
     start = out.find("{")

--- a/lab/validate.py
+++ b/lab/validate.py
@@ -305,7 +305,7 @@ SCENARIOS: list[Scenario] = [
         "FP_intermittent_504",
         fp_intermittent_504,
         expected_vulnerable=False,
-        notes="~30% transient 504s; strict-majority confirmation must suppress",
+        notes="~5% transient 504s; strict-majority confirmation must suppress",
     ),
     # Positives (must flag)
     Scenario(

--- a/src/model.rs
+++ b/src/model.rs
@@ -44,6 +44,13 @@ pub struct CheckResult {
     /// corroborate manually.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub detection_signals: Vec<String>,
+    /// Diagnostic notes about the scan run itself, distinct from
+    /// vulnerability evidence. Currently used to record early-termination
+    /// reasons such as "early_termination:consecutive_fp_rejections=3",
+    /// emitted when the check was abandoned because the backend repeatedly
+    /// hit the control-based FP rule for this payload shape.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<String>,
 }
 
 /// Fingerprint information for JSON output

--- a/src/model.rs
+++ b/src/model.rs
@@ -37,6 +37,13 @@ pub struct CheckResult {
     /// Confidence level of the detection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub confidence: Option<Confidence>,
+    /// Concrete signals that contributed to the detection (e.g.,
+    /// "status_504", "timing_anomaly:3.5x", "body_divergence_vs_control",
+    /// "header_divergence_vs_control:2", "extreme_timing"). Empty when not
+    /// vulnerable. Lets users audit *why* a finding was reported and
+    /// corroborate manually.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub detection_signals: Vec<String>,
 }
 
 /// Fingerprint information for JSON output

--- a/src/output.rs
+++ b/src/output.rs
@@ -81,6 +81,13 @@ pub fn log_plain_results(results: &[CheckResult], vulnerable_count: usize) {
                     attack_ms
                 );
             }
+            if !result.detection_signals.is_empty() {
+                println!(
+                    "{} {}",
+                    "Signals:".bold(),
+                    result.detection_signals.join(", ")
+                );
+            }
             if let Some(ref payload) = result.payload {
                 println!("\n{}", "HTTP Raw Request:".bold());
                 println!("{}", "─".repeat(60).dimmed());

--- a/src/payloads/mod.rs
+++ b/src/payloads/mod.rs
@@ -42,9 +42,12 @@ pub fn format_cookies(cookies: &[String]) -> String {
     }
 }
 
-/// Helper function to check if a payload contains a Transfer-Encoding related header
-/// This handles various obfuscation techniques including control characters in header names
-/// Note: This is only used in tests to verify payload generation, not in production code
+/// Helper function to check if a payload contains a Transfer-Encoding related header.
+/// Handles obfuscation techniques including control characters in header names.
+///
+/// Exposed for integration tests in `tests/payloads_tests.rs` which assert that
+/// generated payloads carry a recognizable TE header. Not used by the scanning
+/// pipeline itself.
 pub fn contains_te_header_pattern(payload: &str) -> bool {
     let payload_lower = payload.to_lowercase();
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -44,6 +44,13 @@ pub const CONTROL_BODY_MIN_BYTES: usize = 32;
 /// detect proxy↔backend desync that persists past the attack — the classic
 /// "second-request" smuggling signature.
 pub const FOLLOWUP_PROBE_COUNT: usize = 3;
+/// When this many consecutive payloads in the same check all detect AND get
+/// rejected by the control-FP rule, abandon the rest of the check. The
+/// backend is producing the same shape-dependent anomaly for every payload
+/// variant, so further iteration is wasted scan time and a strong signal
+/// that the responses are not smuggling-induced. Recorded as a `diagnostics`
+/// note on the CheckResult.
+pub const CONSECUTIVE_FP_REJECTIONS_LIMIT: usize = 3;
 
 /// Parameters for running vulnerability checks
 pub struct CheckParams<'a> {
@@ -821,6 +828,7 @@ fn build_check_result(
     )>,
     timing_threshold: u128,
     baseline_noisy: bool,
+    diagnostics: Vec<String>,
 ) -> (CheckResult, Option<(usize, String)>) {
     if let Some((idx, payload, info, control, followup)) = vulnerability {
         let confidence = compute_confidence(&info, timing_threshold, baseline_noisy);
@@ -846,6 +854,7 @@ fn build_check_result(
             payload: Some(payload.clone()),
             confidence: Some(confidence),
             detection_signals,
+            diagnostics,
         };
         (result, Some((idx, payload)))
     } else {
@@ -861,6 +870,7 @@ fn build_check_result(
             payload: None,
             confidence: None,
             detection_signals: Vec::new(),
+            diagnostics,
         };
         (result, None)
     }
@@ -944,6 +954,12 @@ pub async fn run_checks_for_type(params: CheckParams<'_>) -> Result<CheckResult>
         Option<FollowupObservation>,
     )> = None;
 
+    // Track consecutive control-FP rejections so we can abandon the check if
+    // the backend produces the same shape-dependent anomaly for every
+    // variant — that's a strong signal the responses are not smuggling.
+    let mut consecutive_fp_rejections: usize = 0;
+    let mut early_termination: Option<String> = None;
+
     for (i, attack_request) in params.attack_requests.iter().enumerate() {
         if params.delay > 0 && i > 0 {
             tokio::time::sleep(Duration::from_millis(params.delay)).await;
@@ -1026,6 +1042,22 @@ pub async fn run_checks_for_type(params: CheckParams<'_>) -> Result<CheckResult>
                                 control.duration.as_millis(),
                             );
                         }
+                        consecutive_fp_rejections += 1;
+                        if consecutive_fp_rejections >= CONSECUTIVE_FP_REJECTIONS_LIMIT {
+                            early_termination = Some(format!(
+                                "early_termination:consecutive_fp_rejections={}",
+                                consecutive_fp_rejections
+                            ));
+                            if params.verbose {
+                                println!(
+                                    "  {} {} abandoning check after {} consecutive control-FP rejections",
+                                    "[*]".cyan(),
+                                    params.check_name,
+                                    consecutive_fp_rejections,
+                                );
+                            }
+                            break;
+                        }
                         continue;
                     }
 
@@ -1037,9 +1069,17 @@ pub async fn run_checks_for_type(params: CheckParams<'_>) -> Result<CheckResult>
                         followup_observation,
                     ));
                     break;
+                } else {
+                    // Initial detection didn't confirm — payload was not a
+                    // shape-dependent FP, so this run does not contribute to
+                    // the consecutive-rejection streak.
+                    consecutive_fp_rejections = 0;
                 }
             }
-            Ok(None) => { /* Not vulnerable with this payload, continue */ }
+            Ok(None) => {
+                // No detection signal at all → reset the streak.
+                consecutive_fp_rejections = 0;
+            }
             Err(e) => {
                 if params.verbose {
                     println!(
@@ -1054,6 +1094,7 @@ pub async fn run_checks_for_type(params: CheckParams<'_>) -> Result<CheckResult>
         }
     }
 
+    let diagnostics: Vec<String> = early_termination.into_iter().collect();
     let (result, exported) = build_check_result(
         params.check_name,
         normal_status,
@@ -1061,6 +1102,7 @@ pub async fn run_checks_for_type(params: CheckParams<'_>) -> Result<CheckResult>
         vulnerability_info,
         timing_threshold,
         baseline_noisy,
+        diagnostics,
     );
 
     if let (Some((payload_index, payload)), Some(export_dir)) = (exported, params.export_dir)
@@ -1291,6 +1333,17 @@ mod tests {
             is_connection_timeout: false,
         };
         assert!(!control_indicates_false_positive(&attack, &control, None));
+    }
+
+    #[test]
+    fn consecutive_fp_rejections_limit_constant() {
+        // Document the limit so future tuning is intentional. Value chosen
+        // small enough to abandon noisy backends quickly but large enough
+        // that a few real noisy retries don't trigger early termination.
+        const _: () = assert!(
+            CONSECUTIVE_FP_REJECTIONS_LIMIT >= 2,
+            "limit should require at least 2 consecutive rejections"
+        );
     }
 
     #[test]

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -689,7 +689,10 @@ fn control_indicates_false_positive(
 
 /// Confirm a detected vulnerability by retrying CONFIRMATION_RETRIES times.
 /// - Connection-level timeouts: ALL retries must reproduce (strict; networks are noisy).
-/// - Status/timing signals: strict majority (>N/2) must reproduce.
+/// - Status-only (408/504 without timing anomaly): ALL retries must reproduce —
+///   intermittent gateway-timeout responses are a common non-smuggling cause
+///   and would otherwise pass strict-majority on a single fluke.
+/// - Status+timing or timing-only signals: strict majority (>N/2) must reproduce.
 async fn confirm_vulnerability(
     params: &PayloadCheckParams<'_>,
     initial: &VulnerabilityInfo,
@@ -701,7 +704,11 @@ async fn confirm_vulnerability(
         }
     }
 
-    let confirmed = if initial.is_connection_timeout {
+    let initial_is_status_only = !initial.is_connection_timeout
+        && matches!(initial.status_code, Some(408) | Some(504))
+        && initial.duration.as_millis() <= params.timing_threshold;
+
+    let confirmed = if initial.is_connection_timeout || initial_is_status_only {
         durations.len() == CONFIRMATION_RETRIES
     } else {
         durations.len() * 2 > CONFIRMATION_RETRIES

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -13,8 +13,37 @@ pub const TIMING_MULTIPLIER: u128 = 3;
 pub const MIN_DELAY_MS: u128 = 1000;
 /// Default number of baseline requests for timing measurement
 pub const DEFAULT_BASELINE_COUNT: usize = 3;
-/// Number of retries used to confirm a detected vulnerability
-pub const CONFIRMATION_RETRIES: usize = 2;
+/// Number of retries used to confirm a detected vulnerability.
+/// A larger value enables strict-majority confirmation (>N/2) which reduces
+/// false positives caused by single transient spikes.
+pub const CONFIRMATION_RETRIES: usize = 3;
+/// Absolute buffer in milliseconds added to the *maximum* baseline duration
+/// when computing the timing threshold. Protects against noisy baselines where
+/// natural per-request variance approaches the smuggling-induced delay.
+pub const BASELINE_NOISE_BUFFER_MS: u128 = 500;
+/// Ratio (control_ms * 100 / attack_ms) at or above which a control request is
+/// considered "suspiciously similar" to the attack. When the smuggling-stripped
+/// control takes nearly as long as the attack, the slowness was not caused by
+/// the smuggling artifacts and the finding is rejected as a false positive.
+pub const CONTROL_SIMILARITY_PCT: u128 = 60;
+/// Number of differential control samples to send. The maximum observed control
+/// duration is compared against the attack — using max (rather than median) is
+/// conservative against control flukes that would otherwise let an FP slip
+/// through.
+pub const CONTROL_SAMPLES: usize = 2;
+/// Body-size ratio (smaller_len * 100 / larger_len) at or below which the attack
+/// and control responses are considered structurally different. A large body
+/// divergence is a strong smuggling signal that overrides the timing/status
+/// similarity FP rule.
+pub const CONTROL_BODY_DIVERGENCE_PCT: u128 = 75;
+/// Minimum body size (bytes) required on both sides before the body-divergence
+/// rule kicks in. Avoids tripping the heuristic on near-empty responses where
+/// a few bytes of difference are noise.
+pub const CONTROL_BODY_MIN_BYTES: usize = 32;
+/// Number of fresh follow-up GET probes sent after confirmation+control to
+/// detect proxy↔backend desync that persists past the attack — the classic
+/// "second-request" smuggling signature.
+pub const FOLLOWUP_PROBE_COUNT: usize = 3;
 
 /// Parameters for running vulnerability checks
 pub struct CheckParams<'a> {
@@ -44,20 +73,158 @@ pub struct CheckParams<'a> {
     pub total_checks: usize,
     /// Delay in milliseconds between requests
     pub delay: u64,
-    /// Number of baseline requests for timing measurement
+    /// Number of baseline requests for timing measurement (values < 1 are clamped to 1)
     pub baseline_count: usize,
 }
 
 struct VulnerabilityInfo {
     status: String,
+    status_code: Option<u16>,
     duration: Duration,
+    /// Size of the response body in bytes (post-headers).
+    /// Used to detect structural divergence between attack and control responses.
+    body_length: usize,
+    /// Fingerprint of response headers that frequently shift on desync
+    /// (Content-Type, Server, Content-Length value). Compared between attack
+    /// and control as an orthogonal divergence signal alongside body length.
+    header_fingerprint: ResponseHeaderFingerprint,
     is_connection_timeout: bool,
+}
+
+/// Compact fingerprint of response headers used for divergence comparison.
+/// Stores lowercased values for case-insensitive comparison.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ResponseHeaderFingerprint {
+    content_type: Option<String>,
+    server: Option<String>,
+    content_length: Option<String>,
+}
+
+impl ResponseHeaderFingerprint {
+    /// Parse the header section of an HTTP response into a comparison fingerprint.
+    fn from_response(response: &str) -> Self {
+        let head = match response.split_once("\r\n\r\n") {
+            Some((h, _)) => h,
+            None => response,
+        };
+        let mut fp = ResponseHeaderFingerprint::default();
+        for line in head.lines() {
+            if let Some((name, value)) = line.split_once(':') {
+                let name_lower = name.trim().to_ascii_lowercase();
+                let value_trim = value.trim().to_ascii_lowercase();
+                match name_lower.as_str() {
+                    "content-type" => fp.content_type = Some(value_trim),
+                    "server" => fp.server = Some(value_trim),
+                    "content-length" => fp.content_length = Some(value_trim),
+                    _ => {}
+                }
+            }
+        }
+        fp
+    }
+
+    /// Count of fields where attack and control disagree. A bare presence vs
+    /// absence counts as a disagreement.
+    fn divergence_count(&self, other: &Self) -> u32 {
+        let mut diff = 0u32;
+        if self.content_type != other.content_type {
+            diff += 1;
+        }
+        if self.server != other.server {
+            diff += 1;
+        }
+        if self.content_length != other.content_length {
+            diff += 1;
+        }
+        diff
+    }
+}
+
+/// Extract the response body length (everything after the headers terminator).
+/// Returns 0 if the response is malformed or has no body section.
+fn response_body_length(response: &str) -> usize {
+    response
+        .split_once("\r\n\r\n")
+        .map(|(_, body)| body.len())
+        .unwrap_or(0)
 }
 
 struct BaselineMeasurement {
     status: String,
+    /// HTTP status code from the last baseline probe (parsed once for reuse).
+    status_code: Option<u16>,
+    /// Median baseline duration.
     duration: Duration,
+    /// Maximum baseline duration. Used to derive a noise-aware timing threshold
+    /// so that natural per-request variance does not trigger false positives.
+    max_duration: Duration,
+    /// Response body length from the last baseline probe. Used by follow-up
+    /// probes to detect post-attack body divergence.
+    body_length: usize,
     observed_status_codes: Vec<Option<u16>>,
+}
+
+/// True when the majority of baseline responses are gateway-timeout codes (408/504).
+/// Used to suppress status-only smuggling signals on backends that naturally return those codes.
+/// A single transient timeout in baseline does NOT suppress the signal, which reduces false negatives.
+fn baseline_majority_timeout(baseline_status_codes: &[Option<u16>]) -> bool {
+    if baseline_status_codes.is_empty() {
+        return false;
+    }
+    let timeouts = baseline_status_codes
+        .iter()
+        .filter(|c| matches!(c, Some(408) | Some(504)))
+        .count();
+    timeouts * 2 > baseline_status_codes.len()
+}
+
+/// Median of a non-empty slice of durations. Mutates input by sorting.
+fn median_duration(durations: &mut [Duration]) -> Duration {
+    debug_assert!(!durations.is_empty(), "median of empty slice");
+    durations.sort();
+    durations[durations.len() / 2]
+}
+
+/// Extract the HTTP method (first whitespace-delimited token of the first line)
+/// from a raw request payload. Returns uppercased method.
+fn payload_method(payload: &str) -> String {
+    payload
+        .lines()
+        .next()
+        .and_then(|l| l.split_whitespace().next())
+        .map(|m| m.to_ascii_uppercase())
+        .unwrap_or_else(|| "GET".to_string())
+}
+
+/// Send `count` shape-matched baseline probes that mirror the attack method but
+/// carry no smuggling artifacts (Content-Length: 0, empty body). Used to
+/// augment the GET baseline so timing thresholds account for backend's natural
+/// per-method latency overhead. Returns the durations observed; failures are
+/// silently dropped (the augmentation is best-effort).
+#[allow(clippy::too_many_arguments)]
+async fn method_matched_baseline_durations(
+    host: &str,
+    port: u16,
+    path: &str,
+    method: &str,
+    count: usize,
+    timeout: u64,
+    verbose: bool,
+    use_tls: bool,
+) -> Vec<Duration> {
+    let probe = format!(
+        "{} {} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
+        method, path, host
+    );
+    let mut futures = Vec::with_capacity(count);
+    for _ in 0..count {
+        futures.push(send_request(host, port, &probe, timeout, verbose, use_tls));
+    }
+    futures::future::join_all(futures)
+        .await
+        .into_iter()
+        .filter_map(|r| r.ok().map(|(_, d)| d))
+        .collect()
 }
 
 /// Measure baseline by sending normal requests and computing median timing.
@@ -71,14 +238,16 @@ async fn measure_baseline(
     use_tls: bool,
     baseline_count: usize,
 ) -> Result<BaselineMeasurement> {
+    // Clamp to a minimum of 1 to avoid empty-slice panic and meaningless thresholds.
+    let count = baseline_count.max(1);
+
     let normal_request = format!(
         "GET {} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n",
         path, host
     );
 
-    // Send baseline requests concurrently
-    let mut futures = Vec::with_capacity(baseline_count);
-    for _ in 0..baseline_count {
+    let mut futures = Vec::with_capacity(count);
+    for _ in 0..count {
         futures.push(send_request(
             host,
             port,
@@ -91,26 +260,30 @@ async fn measure_baseline(
 
     let results = futures::future::join_all(futures).await;
 
-    let mut durations = Vec::with_capacity(baseline_count);
-    let mut observed_status_codes = Vec::with_capacity(baseline_count);
+    let mut durations = Vec::with_capacity(count);
+    let mut observed_status_codes = Vec::with_capacity(count);
     let mut last_status = String::new();
+    let mut last_body_length = 0usize;
 
     for result in results {
         let (response, duration) = result?;
         let status_line = response.lines().next().unwrap_or("");
-        let code = parse_status_code(status_line);
-        observed_status_codes.push(code);
+        observed_status_codes.push(parse_status_code(status_line));
         durations.push(duration);
         last_status = status_line.to_string();
+        last_body_length = response_body_length(&response);
     }
 
-    // Use median duration as the baseline
-    durations.sort();
-    let median_duration = durations[durations.len() / 2];
+    let max_duration = durations.iter().copied().max().unwrap_or_default();
+    let median = median_duration(&mut durations);
+    let status_code = parse_status_code(&last_status);
 
     Ok(BaselineMeasurement {
         status: last_status,
-        duration: median_duration,
+        status_code,
+        duration: median,
+        max_duration,
+        body_length: last_body_length,
         observed_status_codes,
     })
 }
@@ -142,23 +315,23 @@ async fn check_single_payload(
         Ok((attack_response, attack_duration)) => {
             let attack_status_line = attack_response.lines().next().unwrap_or("");
             let attack_millis = attack_duration.as_millis();
-
             let status_code = parse_status_code(attack_status_line);
 
-            // Only treat 408/504 as smuggling signal if baseline didn't also produce them
-            let baseline_has_timeout = params
-                .baseline_status_codes
-                .iter()
-                .any(|c| matches!(c, Some(408) | Some(504)));
+            // Only treat 408/504 as a smuggling signal if the baseline did NOT
+            // produce such codes for the majority of probes.
+            let baseline_timeout_majority = baseline_majority_timeout(params.baseline_status_codes);
             let is_timeout_error =
-                matches!(status_code, Some(408) | Some(504)) && !baseline_has_timeout;
+                matches!(status_code, Some(408) | Some(504)) && !baseline_timeout_majority;
             let is_delayed =
                 attack_millis > params.timing_threshold && attack_millis > MIN_DELAY_MS;
 
             if is_timeout_error || is_delayed {
                 Ok(Some(VulnerabilityInfo {
                     status: attack_status_line.to_string(),
+                    status_code,
                     duration: attack_duration,
+                    body_length: response_body_length(&attack_response),
+                    header_fingerprint: ResponseHeaderFingerprint::from_response(&attack_response),
                     is_connection_timeout: false,
                 }))
             } else {
@@ -169,7 +342,10 @@ async fn check_single_payload(
             if matches!(e, SmugglexError::Timeout(_)) {
                 Ok(Some(VulnerabilityInfo {
                     status: "Connection Timeout".to_string(),
+                    status_code: None,
                     duration: Duration::from_secs(params.timeout),
+                    body_length: 0,
+                    header_fingerprint: ResponseHeaderFingerprint::default(),
                     is_connection_timeout: true,
                 }))
             } else {
@@ -179,44 +355,514 @@ async fn check_single_payload(
     }
 }
 
-/// Confirm a detected vulnerability by retrying CONFIRMATION_RETRIES times
-async fn confirm_vulnerability(
-    params: &PayloadCheckParams<'_>,
-    is_connection_timeout: bool,
-) -> bool {
-    let mut confirmed_count = 0;
+/// Outcome of vulnerability confirmation across retries.
+struct ConfirmationResult {
+    confirmed: bool,
+    /// Attack durations from each successful confirmation retry.
+    durations: Vec<Duration>,
+}
 
-    for _ in 0..CONFIRMATION_RETRIES {
-        if let Ok(Some(_)) = check_single_payload(params).await {
-            confirmed_count += 1;
-        }
+/// Observation from a "control" request — a smuggling-stripped sibling of the
+/// attack payload used to validate that the detected anomaly is caused by the
+/// smuggling artifacts themselves, not by the backend's general behavior for
+/// requests of this shape.
+struct ControlObservation {
+    duration: Duration,
+    status_code: Option<u16>,
+    body_length: usize,
+    header_fingerprint: ResponseHeaderFingerprint,
+    is_connection_timeout: bool,
+}
+
+/// True when a payload carries smuggling-specific markers that the control
+/// comparison knows how to strip. Plain HTTP requests (no TE artifact) and
+/// Upgrade/HTTP-2-shaped payloads are excluded because stripping wouldn't
+/// produce a meaningful control.
+fn payload_eligible_for_control(payload: &str) -> bool {
+    let head_end = payload.find("\r\n\r\n").unwrap_or(payload.len());
+    let head_lower = payload[..head_end].to_ascii_lowercase();
+
+    // Skip Upgrade-based / HTTP/2-shaped payloads — stripping TE does not
+    // disable the H2C/H2 smuggling vector, so a control would not be a
+    // meaningful reference.
+    if head_lower.contains("upgrade:") || head_lower.contains("http/2") {
+        return false;
     }
 
-    if is_connection_timeout {
-        // Connection timeout signals require ALL retries to reproduce
-        confirmed_count == CONFIRMATION_RETRIES
-    } else {
-        // Normal signals require at least half to reproduce
-        confirmed_count >= CONFIRMATION_RETRIES.div_ceil(2)
+    // Apply control only to payloads that actually carry TE-related artifacts.
+    head_lower.contains("transfer-encoding")
+        || head_lower.contains("transfer_encoding")
+        || head_lower.contains("transfer encoding")
+        || head_lower.contains("nsfer-encoding")
+}
+
+/// Maximum bytes of synthetic body padding emitted by the control request.
+/// Caps the request size to avoid sending large payloads even if the attack
+/// declared a huge Content-Length.
+const CONTROL_BODY_MAX_BYTES: usize = 4096;
+
+/// Build a "control" version of `payload` with smuggling artifacts removed.
+///
+/// Drops any Transfer-Encoding header (including common obfuscated variants)
+/// and the original Content-Length / body, then re-emits a well-formed request
+/// with a benign body whose size matches the original attack body length
+/// (capped at `CONTROL_BODY_MAX_BYTES`). Matching the body size is important
+/// for shape parity — some backends route requests through different code
+/// paths based on body length, and a zero-length control would not reflect
+/// that timing.
+///
+/// All other headers (Host, Cookie, custom headers, Connection, etc.) are
+/// preserved so the backend processes a request shaped as closely as possible
+/// to the attack minus the smuggling-specific bits.
+fn build_control_request(payload: &str) -> String {
+    let (head, original_body) = match payload.find("\r\n\r\n") {
+        Some(idx) => (&payload[..idx], &payload[idx + 4..]),
+        None => (payload, ""),
+    };
+
+    let mut kept: Vec<&str> = Vec::new();
+    for (i, line) in head.lines().enumerate() {
+        if i == 0 {
+            kept.push(line);
+            continue;
+        }
+        let header_name = line.split(':').next().unwrap_or("");
+        let name_lower = header_name.to_ascii_lowercase();
+        if name_lower.contains("encoding")
+            || name_lower.contains("content-length")
+            || name_lower.contains("content_length")
+        {
+            continue;
+        }
+        kept.push(line);
+    }
+
+    // Match the original body size (capped) with benign ASCII padding so the
+    // backend takes the same shape-conditional code paths it would for the
+    // attack, minus the smuggling tricks.
+    let body_len = original_body.len().min(CONTROL_BODY_MAX_BYTES);
+    let mut result = String::with_capacity(payload.len());
+    for line in kept {
+        result.push_str(line);
+        result.push_str("\r\n");
+    }
+    result.push_str(&format!("Content-Length: {}\r\n\r\n", body_len));
+    if body_len > 0 {
+        result.extend(std::iter::repeat_n('x', body_len));
+    }
+    result
+}
+
+/// Send a single control request and observe its timing/status/body. Returns
+/// `None` if the network layer errored in a way the caller cannot reason about.
+async fn observe_control_once(
+    params: &PayloadCheckParams<'_>,
+    control_request: &str,
+) -> Option<ControlObservation> {
+    match send_request(
+        params.host,
+        params.port,
+        control_request,
+        params.timeout,
+        params.verbose,
+        params.use_tls,
+    )
+    .await
+    {
+        Ok((response, duration)) => {
+            let status_line = response.lines().next().unwrap_or("");
+            Some(ControlObservation {
+                duration,
+                status_code: parse_status_code(status_line),
+                body_length: response_body_length(&response),
+                header_fingerprint: ResponseHeaderFingerprint::from_response(&response),
+                is_connection_timeout: false,
+            })
+        }
+        Err(SmugglexError::Timeout(_)) => Some(ControlObservation {
+            duration: Duration::from_secs(params.timeout),
+            status_code: None,
+            body_length: 0,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: true,
+        }),
+        Err(_) => None,
     }
 }
 
-/// Compute confidence level based on the nature of the detection signals
-fn compute_confidence(info: &VulnerabilityInfo, timing_threshold: u128) -> Confidence {
+/// Send `CONTROL_SAMPLES` control requests and aggregate them conservatively:
+/// duration is the MAX (worst case favors FP rejection of borderline detections),
+/// status_code/body_length is taken from the slowest sample, and connection
+/// timeout is set if ANY sample timed out.
+///
+/// Multiple samples protect against single-control flukes (a transient fast
+/// response that would otherwise let a real FP slip through) at the cost of one
+/// extra request per confirmed vulnerability.
+async fn observe_control(
+    params: &PayloadCheckParams<'_>,
+    control_request: &str,
+) -> Option<ControlObservation> {
+    let mut samples: Vec<ControlObservation> = Vec::with_capacity(CONTROL_SAMPLES);
+    for _ in 0..CONTROL_SAMPLES {
+        if let Some(obs) = observe_control_once(params, control_request).await {
+            samples.push(obs);
+        }
+    }
+    if samples.is_empty() {
+        return None;
+    }
+    let worst_idx = samples
+        .iter()
+        .enumerate()
+        .max_by_key(|(_, s)| s.duration)
+        .map(|(i, _)| i)
+        .unwrap_or(0);
+    let any_timeout = samples.iter().any(|s| s.is_connection_timeout);
+    let worst = &samples[worst_idx];
+    Some(ControlObservation {
+        duration: worst.duration,
+        status_code: worst.status_code,
+        body_length: worst.body_length,
+        header_fingerprint: worst.header_fingerprint.clone(),
+        is_connection_timeout: any_timeout,
+    })
+}
+
+/// Aggregated observation from `FOLLOWUP_PROBE_COUNT` post-attack follow-up
+/// GETs, used to detect persistent proxy↔backend desync that outlives the
+/// attack request itself.
+struct FollowupObservation {
+    /// Number of follow-up probes whose response diverged from baseline (by
+    /// status code or substantial body-length difference).
+    diverging: usize,
+    /// Total number of follow-up probes actually sent (failures excluded).
+    total: usize,
+}
+
+impl FollowupObservation {
+    fn has_divergence(&self) -> bool {
+        self.diverging > 0
+    }
+}
+
+/// Send `FOLLOWUP_PROBE_COUNT` fresh-connection GET probes against the target
+/// path and count how many returned a response that diverges from the baseline
+/// (status code differs, or body length differs structurally per
+/// `bodies_diverge`). Each probe uses `Connection: close` so the scanner does
+/// not reuse the attack socket — divergence here therefore reflects state
+/// shared between the proxy and the backend pool, the canonical desync
+/// signature for HTTP request smuggling.
+async fn observe_followup_divergence(
+    params: &PayloadCheckParams<'_>,
+    path: &str,
+    baseline: &BaselineMeasurement,
+) -> FollowupObservation {
+    let probe = format!(
+        "GET {} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n",
+        path, params.host
+    );
+    let mut diverging = 0usize;
+    let mut total = 0usize;
+    for _ in 0..FOLLOWUP_PROBE_COUNT {
+        let res = send_request(
+            params.host,
+            params.port,
+            &probe,
+            params.timeout,
+            params.verbose,
+            params.use_tls,
+        )
+        .await;
+        match res {
+            Ok((response, _)) => {
+                total += 1;
+                let status_line = response.lines().next().unwrap_or("");
+                let status_code = parse_status_code(status_line);
+                let body_len = response_body_length(&response);
+                let status_diverged = status_code != baseline.status_code;
+                let body_diverged = bodies_diverge(body_len, baseline.body_length);
+                if status_diverged || body_diverged {
+                    diverging += 1;
+                }
+            }
+            // Network-level errors on a fresh follow-up connection can themselves
+            // be a desync signal (backend tearing down poisoned connections),
+            // but they're also noisy. Count them but do not over-weight.
+            Err(SmugglexError::Timeout(_)) => {
+                total += 1;
+                diverging += 1;
+            }
+            Err(_) => {
+                // Other connection errors aren't reliable signals — skip.
+            }
+        }
+    }
+    FollowupObservation { diverging, total }
+}
+
+/// True if attack and control responses have structurally different bodies
+/// (the smaller body is less than `CONTROL_BODY_DIVERGENCE_PCT`% of the larger).
+///
+/// Requires the LARGER body to exceed `CONTROL_BODY_MIN_BYTES` so divergence
+/// is only claimed when there is enough material on at least one side to be
+/// confident the difference is structural — both sides being tiny (e.g., empty
+/// or minimal error pages) carries too little signal.
+fn bodies_diverge(attack_body: usize, control_body: usize) -> bool {
+    let larger = attack_body.max(control_body);
+    if larger < CONTROL_BODY_MIN_BYTES {
+        return false;
+    }
+    let smaller = attack_body.min(control_body) as u128;
+    let larger = larger as u128;
+    smaller.saturating_mul(100) < larger.saturating_mul(CONTROL_BODY_DIVERGENCE_PCT)
+}
+
+/// Decide whether the control response is "suspiciously similar" to the attack
+/// response, indicating the detected signal stems from the backend's natural
+/// behavior for this request shape rather than from smuggling artifacts.
+fn control_indicates_false_positive(
+    attack: &VulnerabilityInfo,
+    control: &ControlObservation,
+    followup: Option<&FollowupObservation>,
+) -> bool {
+    // ESCAPE: post-attack follow-up GET diverged from baseline → backend state
+    // was perturbed by the attack and persisted into a subsequent request.
+    // This is the canonical "second-request" smuggling signature and overrides
+    // any timing/status FP rule.
+    if followup.is_some_and(|f| f.has_divergence()) {
+        return false;
+    }
+
+    // ESCAPE: attack and control returned structurally different response
+    // bodies → the smuggling artifacts changed how the backend interpreted the
+    // request (the canonical desync signature). Keep the finding regardless of
+    // timing/status similarity.
+    if bodies_diverge(attack.body_length, control.body_length) {
+        return false;
+    }
+
+    // ESCAPE: response header set diverges between attack and control. A change
+    // in Content-Type, Server, or the Content-Length header value is a strong
+    // signal that the backend interpreted the request differently — i.e. a
+    // desync — even when body lengths happen to be similar.
+    if attack
+        .header_fingerprint
+        .divergence_count(&control.header_fingerprint)
+        >= 2
+    {
+        return false;
+    }
+
+    // Connection-level timeout on the control too → backend cannot handle the
+    // request shape at all, irrespective of smuggling tricks.
+    if attack.is_connection_timeout && control.is_connection_timeout {
+        return true;
+    }
+
+    // Both attack and control returned a gateway-timeout status → the backend
+    // returns 408/504 for this shape independent of smuggling artifacts.
+    let attack_is_timeout_status = matches!(attack.status_code, Some(408) | Some(504));
+    let control_is_timeout_status = matches!(control.status_code, Some(408) | Some(504));
+    if attack_is_timeout_status && control_is_timeout_status {
+        return true;
+    }
+
+    // Control duration is within CONTROL_SIMILARITY_PCT% of the attack duration
+    // → the slowness is intrinsic to the request shape, not the smuggling.
+    let attack_ms = attack.duration.as_millis();
+    let control_ms = control.duration.as_millis();
+    if attack_ms > 0
+        && control_ms.saturating_mul(100) >= attack_ms.saturating_mul(CONTROL_SIMILARITY_PCT)
+    {
+        return true;
+    }
+
+    false
+}
+
+/// Confirm a detected vulnerability by retrying CONFIRMATION_RETRIES times.
+/// - Connection-level timeouts: ALL retries must reproduce (strict; networks are noisy).
+/// - Status/timing signals: strict majority (>N/2) must reproduce.
+async fn confirm_vulnerability(
+    params: &PayloadCheckParams<'_>,
+    initial: &VulnerabilityInfo,
+) -> ConfirmationResult {
+    let mut durations = Vec::with_capacity(CONFIRMATION_RETRIES);
+    for _ in 0..CONFIRMATION_RETRIES {
+        if let Ok(Some(info)) = check_single_payload(params).await {
+            durations.push(info.duration);
+        }
+    }
+
+    let confirmed = if initial.is_connection_timeout {
+        durations.len() == CONFIRMATION_RETRIES
+    } else {
+        durations.len() * 2 > CONFIRMATION_RETRIES
+    };
+
+    ConfirmationResult {
+        confirmed,
+        durations,
+    }
+}
+
+/// True when the baseline shows enough natural variance (spread between max
+/// and median exceeding `BASELINE_NOISE_BUFFER_MS`) that pure timing
+/// detections become unreliable. Used to demote confidence — the finding
+/// still stands but is reported as Low so users know to verify manually.
+fn baseline_is_noisy(median: Duration, max: Duration) -> bool {
+    max.as_millis() > median.as_millis() + BASELINE_NOISE_BUFFER_MS
+}
+
+/// Compute confidence level based on the nature of the detection signals.
+///
+/// `timing_threshold` is the per-target dynamic threshold; the absolute floor
+/// (`MIN_DELAY_MS * 2`) prevents fast targets where any timing-detected attack
+/// would trivially exceed `threshold * 2` from always reaching High confidence.
+///
+/// `baseline_noisy` reflects whether the baseline carries enough variance that
+/// a pure-timing signal cannot be trusted at face value — such detections are
+/// demoted to Low so the user knows to corroborate manually.
+fn compute_confidence(
+    info: &VulnerabilityInfo,
+    timing_threshold: u128,
+    baseline_noisy: bool,
+) -> Confidence {
     if info.is_connection_timeout {
         return Confidence::Low;
     }
 
-    let status_code = parse_status_code(&info.status);
-    let is_timeout_status = matches!(status_code, Some(408) | Some(504));
+    let is_timeout_status = matches!(info.status_code, Some(408) | Some(504));
     let attack_millis = info.duration.as_millis();
     let is_timing_anomaly = attack_millis > timing_threshold && attack_millis > MIN_DELAY_MS;
-    let is_extreme_timing = timing_threshold > 0 && attack_millis > timing_threshold * 2;
+    let is_extreme_timing = timing_threshold > 0
+        && attack_millis > timing_threshold * 2
+        && attack_millis > MIN_DELAY_MS * 2;
+
+    // Demote timing-only detections from a noisy baseline to Low — the timing
+    // delta isn't reliable evidence on its own.
+    if baseline_noisy && !is_timeout_status && !is_extreme_timing {
+        return Confidence::Low;
+    }
 
     if (is_timeout_status && is_timing_anomaly) || is_extreme_timing {
         Confidence::High
     } else {
         Confidence::Medium
+    }
+}
+
+/// Collect the discrete signals that contributed to detection, for transparency.
+/// Returned as human-readable tags; ordering is stable across runs.
+fn collect_detection_signals(
+    info: &VulnerabilityInfo,
+    normal_duration: Duration,
+    timing_threshold: u128,
+    baseline_noisy: bool,
+    control: Option<&ControlObservation>,
+    followup: Option<&FollowupObservation>,
+) -> Vec<String> {
+    let mut signals = Vec::new();
+    if info.is_connection_timeout {
+        signals.push("connection_timeout".to_string());
+    }
+    match info.status_code {
+        Some(408) => signals.push("status_408".to_string()),
+        Some(504) => signals.push("status_504".to_string()),
+        _ => {}
+    }
+    let attack_ms = info.duration.as_millis();
+    let normal_ms = normal_duration.as_millis();
+    if attack_ms > timing_threshold && attack_ms > MIN_DELAY_MS {
+        let ratio = if normal_ms > 0 {
+            attack_ms as f64 / normal_ms as f64
+        } else {
+            attack_ms as f64 / 1.0
+        };
+        signals.push(format!("timing_anomaly:{:.1}x", ratio));
+    }
+    if timing_threshold > 0 && attack_ms > timing_threshold * 2 && attack_ms > MIN_DELAY_MS * 2 {
+        signals.push("extreme_timing".to_string());
+    }
+    if baseline_noisy {
+        signals.push("baseline_noisy".to_string());
+    }
+    if let Some(c) = control {
+        if bodies_diverge(info.body_length, c.body_length) {
+            signals.push("body_divergence_vs_control".to_string());
+        }
+        let header_diff = info
+            .header_fingerprint
+            .divergence_count(&c.header_fingerprint);
+        if header_diff >= 2 {
+            signals.push(format!("header_divergence_vs_control:{}", header_diff));
+        }
+    }
+    if let Some(f) = followup
+        && f.has_divergence()
+    {
+        signals.push(format!("followup_divergence:{}/{}", f.diverging, f.total));
+    }
+    signals
+}
+
+/// Build the final `CheckResult` from collected scan state.
+#[allow(clippy::type_complexity)]
+fn build_check_result(
+    check_name: &str,
+    normal_status: String,
+    normal_duration: Duration,
+    vulnerability: Option<(
+        usize,
+        String,
+        VulnerabilityInfo,
+        Option<ControlObservation>,
+        Option<FollowupObservation>,
+    )>,
+    timing_threshold: u128,
+    baseline_noisy: bool,
+) -> (CheckResult, Option<(usize, String)>) {
+    if let Some((idx, payload, info, control, followup)) = vulnerability {
+        let confidence = compute_confidence(&info, timing_threshold, baseline_noisy);
+        let detection_signals = collect_detection_signals(
+            &info,
+            normal_duration,
+            timing_threshold,
+            baseline_noisy,
+            control.as_ref(),
+            followup.as_ref(),
+        );
+        let attack_status = info.status;
+        let attack_duration_ms = info.duration.as_millis() as u64;
+        let result = CheckResult {
+            check_type: check_name.to_string(),
+            vulnerable: true,
+            payload_index: Some(idx),
+            normal_status,
+            attack_status: Some(attack_status),
+            normal_duration_ms: normal_duration.as_millis() as u64,
+            attack_duration_ms: Some(attack_duration_ms),
+            timestamp: Utc::now().to_rfc3339(),
+            payload: Some(payload.clone()),
+            confidence: Some(confidence),
+            detection_signals,
+        };
+        (result, Some((idx, payload)))
+    } else {
+        let result = CheckResult {
+            check_type: check_name.to_string(),
+            vulnerable: false,
+            payload_index: None,
+            normal_status,
+            attack_status: None,
+            normal_duration_ms: normal_duration.as_millis() as u64,
+            attack_duration_ms: None,
+            timestamp: Utc::now().to_rfc3339(),
+            payload: None,
+            confidence: None,
+            detection_signals: Vec::new(),
+        };
+        (result, None)
     }
 }
 
@@ -231,7 +877,6 @@ pub async fn run_checks_for_type(params: CheckParams<'_>) -> Result<CheckResult>
         ));
     }
 
-    // Measure baseline with multiple requests
     let baseline = measure_baseline(
         params.host,
         params.port,
@@ -242,11 +887,62 @@ pub async fn run_checks_for_type(params: CheckParams<'_>) -> Result<CheckResult>
         params.baseline_count,
     )
     .await?;
-    let normal_status = baseline.status;
+    let normal_status = baseline.status.clone();
     let normal_duration = baseline.duration;
+    // Noise-aware threshold: a slow attack must beat BOTH the relative
+    // multiplier over the median AND the worst observed baseline plus a buffer.
+    // This prevents a single slow baseline sample from inflating noise that
+    // looks like an anomaly.
+    // Augment the GET baseline with a small set of method-matched probes when
+    // attacks use a different method. This corrects timing thresholds on
+    // backends where POST handling is naturally slower than GET — a common
+    // false-positive source where the GET baseline understates the per-request
+    // floor for the actual attack shape.
+    let attack_method = params
+        .attack_requests
+        .first()
+        .map(|p| payload_method(p))
+        .unwrap_or_else(|| "GET".to_string());
+    let mut max_baseline = baseline.max_duration;
+    let mut median_baseline = normal_duration;
+    if attack_method != "GET" && !attack_method.is_empty() {
+        let extra = method_matched_baseline_durations(
+            params.host,
+            params.port,
+            params.path,
+            &attack_method,
+            params.baseline_count.max(1),
+            params.timeout,
+            params.verbose,
+            params.use_tls,
+        )
+        .await;
+        if !extra.is_empty() {
+            if let Some(extra_max) = extra.iter().copied().max()
+                && extra_max > max_baseline
+            {
+                max_baseline = extra_max;
+            }
+            let mut combined: Vec<Duration> = extra;
+            combined.push(normal_duration);
+            median_baseline = median_duration(&mut combined);
+        }
+    }
 
-    let mut vulnerability_info = None;
-    let timing_threshold = normal_duration.as_millis() * TIMING_MULTIPLIER;
+    let timing_threshold = std::cmp::max(
+        median_baseline.as_millis() * TIMING_MULTIPLIER,
+        max_baseline.as_millis() + BASELINE_NOISE_BUFFER_MS,
+    );
+    let baseline_noisy = baseline_is_noisy(median_baseline, max_baseline);
+
+    #[allow(clippy::type_complexity)]
+    let mut vulnerability_info: Option<(
+        usize,
+        String,
+        VulnerabilityInfo,
+        Option<ControlObservation>,
+        Option<FollowupObservation>,
+    )> = None;
 
     for (i, attack_request) in params.attack_requests.iter().enumerate() {
         if params.delay > 0 && i > 0 {
@@ -279,13 +975,67 @@ pub async fn run_checks_for_type(params: CheckParams<'_>) -> Result<CheckResult>
         };
 
         match check_single_payload(&payload_params).await {
-            Ok(Some(info)) => {
-                // Confirm the vulnerability with retries
-                let confirmed =
-                    confirm_vulnerability(&payload_params, info.is_connection_timeout).await;
+            Ok(Some(mut info)) => {
+                let confirmation = confirm_vulnerability(&payload_params, &info).await;
+                if confirmation.confirmed {
+                    // Use the median of (initial + retry) durations to dampen
+                    // the influence of a single transient spike on confidence.
+                    let mut all_durations = Vec::with_capacity(confirmation.durations.len() + 1);
+                    all_durations.push(info.duration);
+                    all_durations.extend(confirmation.durations);
+                    info.duration = median_duration(&mut all_durations);
 
-                if confirmed {
-                    vulnerability_info = Some((i, attack_request.clone(), info));
+                    // Differential control check: send a smuggling-stripped
+                    // sibling of the payload. Skipped for payloads where
+                    // stripping isn't meaningful (H2C/H2 or non-TE payloads).
+                    let mut control_observation: Option<ControlObservation> = None;
+                    if payload_eligible_for_control(attack_request) {
+                        let control_request = build_control_request(attack_request);
+                        if let Some(control) =
+                            observe_control(&payload_params, &control_request).await
+                        {
+                            control_observation = Some(control);
+                        }
+                    }
+
+                    // Post-attack follow-up probes: detect proxy↔backend
+                    // desync that persists past the attack. Strong escape
+                    // signal — overrides the control FP rule.
+                    let followup_observation = Some(
+                        observe_followup_divergence(&payload_params, params.path, &baseline).await,
+                    );
+
+                    // FP rejection considers both control similarity AND the
+                    // absence of follow-up divergence. If the follow-up
+                    // diverged, the finding survives FP rejection.
+                    if let Some(control) = control_observation.as_ref()
+                        && control_indicates_false_positive(
+                            &info,
+                            control,
+                            followup_observation.as_ref(),
+                        )
+                    {
+                        if params.verbose {
+                            println!(
+                                "  {} {} payload #{} rejected as false positive (control matched attack: status={:?}, attack={}ms, control={}ms)",
+                                "[*]".cyan(),
+                                params.check_name,
+                                i,
+                                control.status_code,
+                                info.duration.as_millis(),
+                                control.duration.as_millis(),
+                            );
+                        }
+                        continue;
+                    }
+
+                    vulnerability_info = Some((
+                        i,
+                        attack_request.clone(),
+                        info,
+                        control_observation,
+                        followup_observation,
+                    ));
                     break;
                 }
             }
@@ -304,36 +1054,22 @@ pub async fn run_checks_for_type(params: CheckParams<'_>) -> Result<CheckResult>
         }
     }
 
-    let (
-        vulnerable,
-        result_payload_index,
-        result_payload,
-        result_attack_status,
-        last_attack_duration,
-        confidence,
-    ) = if let Some((i, payload, info)) = vulnerability_info {
-        let conf = compute_confidence(&info, timing_threshold);
-        (
-            true,
-            Some(i),
-            Some(payload),
-            Some(info.status),
-            Some(info.duration),
-            Some(conf),
-        )
-    } else {
-        (false, None, None, None, None, None)
-    };
+    let (result, exported) = build_check_result(
+        params.check_name,
+        normal_status,
+        normal_duration,
+        vulnerability_info,
+        timing_threshold,
+        baseline_noisy,
+    );
 
-    if vulnerable
-        && let (Some(export_dir), Some(payload_index), Some(payload)) =
-            (params.export_dir, result_payload_index, &result_payload)
+    if let (Some((payload_index, payload)), Some(export_dir)) = (exported, params.export_dir)
         && let Err(e) = export_payload(
             export_dir,
             params.host,
             params.check_name,
             payload_index,
-            payload,
+            &payload,
             params.use_tls,
         )
         && params.verbose
@@ -341,16 +1077,468 @@ pub async fn run_checks_for_type(params: CheckParams<'_>) -> Result<CheckResult>
         println!("  {} Failed to export payload: {}", "[!]".yellow(), e);
     }
 
-    Ok(CheckResult {
-        check_type: params.check_name.to_string(),
-        vulnerable,
-        payload_index: result_payload_index,
-        normal_status,
-        attack_status: result_attack_status,
-        normal_duration_ms: normal_duration.as_millis() as u64,
-        attack_duration_ms: last_attack_duration.map(|d| d.as_millis() as u64),
-        timestamp: Utc::now().to_rfc3339(),
-        payload: result_payload,
-        confidence,
-    })
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn baseline_majority_timeout_empty_is_false() {
+        assert!(!baseline_majority_timeout(&[]));
+    }
+
+    #[test]
+    fn baseline_majority_timeout_single_504_is_majority() {
+        assert!(baseline_majority_timeout(&[Some(504)]));
+    }
+
+    #[test]
+    fn baseline_majority_timeout_minority_not_flagged() {
+        // 1 of 3 is NOT majority (used to be "any" → now requires majority)
+        assert!(!baseline_majority_timeout(&[
+            Some(504),
+            Some(200),
+            Some(200)
+        ]));
+    }
+
+    #[test]
+    fn baseline_majority_timeout_majority_flagged() {
+        assert!(baseline_majority_timeout(&[
+            Some(504),
+            Some(504),
+            Some(200)
+        ]));
+    }
+
+    #[test]
+    fn payload_eligible_skips_plain_request() {
+        let p = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        assert!(!payload_eligible_for_control(p));
+    }
+
+    #[test]
+    fn payload_eligible_for_te_payload() {
+        let p = "POST / HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\nContent-Length: 6\r\n\r\n0\r\n\r\nG";
+        assert!(payload_eligible_for_control(p));
+    }
+
+    #[test]
+    fn payload_eligible_skips_h2c_upgrade() {
+        // H2C payload has TE-related body but the Upgrade header makes control
+        // comparison meaningless (TE stripping doesn't disable H2C smuggling).
+        let p = "POST / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: h2c\r\nTransfer-Encoding: chunked\r\n\r\n";
+        assert!(!payload_eligible_for_control(p));
+    }
+
+    #[test]
+    fn build_control_strips_transfer_encoding() {
+        // Original attack body "0\r\n\r\nG" is 6 bytes — control should match
+        // that size with benign ASCII padding.
+        let p = "POST /a HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\nContent-Length: 6\r\n\r\n0\r\n\r\nG";
+        let control = build_control_request(p);
+        let lower = control.to_ascii_lowercase();
+        assert!(!lower.contains("transfer-encoding"));
+        assert!(lower.contains("content-length: 6\r\n"));
+        // Headers preserved
+        assert!(control.starts_with("POST /a HTTP/1.1\r\n"));
+        assert!(control.contains("Host: x"));
+        // Body present, of declared length, benign padding only.
+        let (_, body) = control.rsplit_once("\r\n\r\n").unwrap();
+        assert_eq!(body.len(), 6);
+        assert!(body.chars().all(|c| c == 'x'));
+    }
+
+    #[test]
+    fn build_control_zero_body_when_attack_has_none() {
+        let p = "POST / HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n";
+        let control = build_control_request(p);
+        assert!(control.contains("Content-Length: 0\r\n"));
+        let (_, body) = control.rsplit_once("\r\n\r\n").unwrap();
+        assert!(body.is_empty());
+    }
+
+    #[test]
+    fn build_control_caps_body_at_max_bytes() {
+        // Construct an attack payload with a body bigger than the cap.
+        let huge_body = "z".repeat(CONTROL_BODY_MAX_BYTES + 1000);
+        let p = format!(
+            "POST / HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\nContent-Length: 99999\r\n\r\n{}",
+            huge_body
+        );
+        let control = build_control_request(&p);
+        assert!(control.contains(&format!("Content-Length: {}\r\n", CONTROL_BODY_MAX_BYTES)));
+        let (_, body) = control.rsplit_once("\r\n\r\n").unwrap();
+        assert_eq!(body.len(), CONTROL_BODY_MAX_BYTES);
+    }
+
+    #[test]
+    fn build_control_preserves_custom_headers() {
+        let p = "POST / HTTP/1.1\r\nHost: x\r\nCookie: s=1\r\nX-Custom: v\r\nTransfer-Encoding: chunked\r\nContent-Length: 6\r\n\r\n0\r\n\r\nG";
+        let control = build_control_request(p);
+        assert!(control.contains("Cookie: s=1"));
+        assert!(control.contains("X-Custom: v"));
+    }
+
+    #[test]
+    fn control_fp_when_both_504() {
+        let attack = VulnerabilityInfo {
+            status: "HTTP/1.1 504".into(),
+            status_code: Some(504),
+            duration: Duration::from_millis(500),
+            body_length: 20,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        let control = ControlObservation {
+            duration: Duration::from_millis(50),
+            status_code: Some(504),
+            body_length: 20,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        assert!(control_indicates_false_positive(&attack, &control, None));
+    }
+
+    #[test]
+    fn control_fp_when_similar_timing() {
+        let attack = VulnerabilityInfo {
+            status: "HTTP/1.1 200".into(),
+            status_code: Some(200),
+            duration: Duration::from_millis(2000),
+            body_length: 13,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        let control = ControlObservation {
+            duration: Duration::from_millis(1500), // 75% of attack
+            status_code: Some(200),
+            body_length: 13,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        assert!(control_indicates_false_positive(&attack, &control, None));
+    }
+
+    #[test]
+    fn control_kept_when_fast_and_different_status() {
+        let attack = VulnerabilityInfo {
+            status: "HTTP/1.1 504".into(),
+            status_code: Some(504),
+            duration: Duration::from_millis(2000),
+            body_length: 0,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        let control = ControlObservation {
+            duration: Duration::from_millis(50), // 2.5% of attack — different shape
+            status_code: Some(200),
+            body_length: 13,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        assert!(!control_indicates_false_positive(&attack, &control, None));
+    }
+
+    #[test]
+    fn body_divergence_ignores_when_both_tiny() {
+        // Both sides below CONTROL_BODY_MIN_BYTES → not enough signal.
+        assert!(!bodies_diverge(5, 5));
+        assert!(!bodies_diverge(20, 30));
+    }
+
+    #[test]
+    fn body_divergence_detects_tiny_vs_large() {
+        // One side tiny, the other substantial — that IS structural divergence.
+        // (Real smuggling case: attack returns small error page, control returns
+        // full normal response.)
+        assert!(bodies_diverge(10, 1000));
+        assert!(bodies_diverge(1000, 10));
+    }
+
+    #[test]
+    fn body_divergence_detects_large_size_difference() {
+        // 200 bytes vs 50 bytes: 50/200 = 25% < 75% threshold → diverge.
+        assert!(bodies_diverge(200, 50));
+        assert!(bodies_diverge(50, 200));
+    }
+
+    #[test]
+    fn body_divergence_skips_close_sizes() {
+        // 200 bytes vs 180 bytes: 180/200 = 90% > 75% → not divergent.
+        assert!(!bodies_diverge(200, 180));
+    }
+
+    #[test]
+    fn control_kept_when_bodies_diverge_despite_similar_timing() {
+        // Attack and control have similar timing (would normally trigger FP)
+        // but bodies differ substantially → escape clause keeps the finding.
+        let attack = VulnerabilityInfo {
+            status: "HTTP/1.1 200".into(),
+            status_code: Some(200),
+            duration: Duration::from_millis(2000),
+            body_length: 50, // small response (e.g., error page)
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        let control = ControlObservation {
+            duration: Duration::from_millis(1900), // 95% of attack — very similar timing
+            status_code: Some(200),
+            body_length: 5000, // large response (normal content)
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        assert!(!control_indicates_false_positive(&attack, &control, None));
+    }
+
+    #[test]
+    fn payload_method_extracts_post() {
+        let p = "POST /a HTTP/1.1\r\nHost: x\r\n\r\n";
+        assert_eq!(payload_method(p), "POST");
+    }
+
+    #[test]
+    fn payload_method_uppercases() {
+        let p = "patch /a HTTP/1.1\r\nHost: x\r\n\r\n";
+        assert_eq!(payload_method(p), "PATCH");
+    }
+
+    #[test]
+    fn payload_method_defaults_to_get_on_empty() {
+        assert_eq!(payload_method(""), "GET");
+    }
+
+    #[test]
+    fn baseline_noisy_when_spread_exceeds_buffer() {
+        assert!(baseline_is_noisy(
+            Duration::from_millis(100),
+            Duration::from_millis(700)
+        ));
+    }
+
+    #[test]
+    fn baseline_not_noisy_when_spread_within_buffer() {
+        assert!(!baseline_is_noisy(
+            Duration::from_millis(400),
+            Duration::from_millis(400)
+        ));
+        assert!(!baseline_is_noisy(
+            Duration::from_millis(100),
+            Duration::from_millis(599)
+        ));
+    }
+
+    #[test]
+    fn timing_only_demoted_to_low_on_noisy_baseline() {
+        let info = VulnerabilityInfo {
+            status: "HTTP/1.1 200".into(),
+            status_code: Some(200),
+            duration: Duration::from_millis(2000),
+            body_length: 13,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        // Noisy baseline, timing-only signal → Low.
+        assert_eq!(compute_confidence(&info, 1200, true), Confidence::Low);
+    }
+
+    #[test]
+    fn status_signal_keeps_confidence_on_noisy_baseline() {
+        let info = VulnerabilityInfo {
+            status: "HTTP/1.1 504".into(),
+            status_code: Some(504),
+            duration: Duration::from_millis(2000),
+            body_length: 0,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        // 504 + timing anomaly is High regardless of baseline noise.
+        assert_eq!(compute_confidence(&info, 1200, true), Confidence::High);
+    }
+
+    #[test]
+    fn extreme_timing_keeps_confidence_on_noisy_baseline() {
+        let info = VulnerabilityInfo {
+            status: "HTTP/1.1 200".into(),
+            status_code: Some(200),
+            duration: Duration::from_millis(5000),
+            body_length: 13,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        // 5000ms > 1200*2=2400 AND > MIN_DELAY_MS*2=2000 → extreme → High even
+        // on noisy baseline.
+        assert_eq!(compute_confidence(&info, 1200, true), Confidence::High);
+    }
+
+    #[test]
+    fn header_fingerprint_extracts_known_fields() {
+        let r = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nServer: nginx\r\nContent-Length: 123\r\nX-Other: ignore\r\n\r\nbody";
+        let fp = ResponseHeaderFingerprint::from_response(r);
+        assert_eq!(fp.content_type.as_deref(), Some("text/html"));
+        assert_eq!(fp.server.as_deref(), Some("nginx"));
+        assert_eq!(fp.content_length.as_deref(), Some("123"));
+    }
+
+    #[test]
+    fn header_fingerprint_divergence_count() {
+        let a = ResponseHeaderFingerprint::from_response(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nServer: nginx\r\nContent-Length: 100\r\n\r\nb",
+        );
+        let b = ResponseHeaderFingerprint::from_response(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nServer: nginx\r\nContent-Length: 99\r\n\r\nb",
+        );
+        // content-type differs, content-length differs, server same → 2.
+        assert_eq!(a.divergence_count(&b), 2);
+    }
+
+    #[test]
+    fn control_kept_when_headers_diverge_despite_similar_timing() {
+        // Attack and control have similar timing AND similar body length, but
+        // response headers differ in two fields → escape via header divergence.
+        let attack = VulnerabilityInfo {
+            status: "HTTP/1.1 200".into(),
+            status_code: Some(200),
+            duration: Duration::from_millis(2000),
+            body_length: 200,
+            header_fingerprint: ResponseHeaderFingerprint::from_response(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nServer: backend-v2\r\nContent-Length: 200\r\n\r\n",
+            ),
+            is_connection_timeout: false,
+        };
+        let control = ControlObservation {
+            duration: Duration::from_millis(1900),
+            status_code: Some(200),
+            body_length: 210,
+            header_fingerprint: ResponseHeaderFingerprint::from_response(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nServer: proxy-edge\r\nContent-Length: 210\r\n\r\n",
+            ),
+            is_connection_timeout: false,
+        };
+        // bodies are 200 vs 210 (95% similar — not divergent). Headers differ
+        // in content-type, server, content-length (3 fields) → ≥2 → escape.
+        assert!(!control_indicates_false_positive(&attack, &control, None));
+    }
+
+    #[test]
+    fn control_fp_when_only_one_header_diverges() {
+        // A single header divergence is not enough — could be reverse proxy
+        // metadata noise. Need ≥2 to escape.
+        let attack = VulnerabilityInfo {
+            status: "HTTP/1.1 200".into(),
+            status_code: Some(200),
+            duration: Duration::from_millis(2000),
+            body_length: 13,
+            header_fingerprint: ResponseHeaderFingerprint::from_response(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nServer: nginx\r\nContent-Length: 13\r\n\r\n",
+            ),
+            is_connection_timeout: false,
+        };
+        let control = ControlObservation {
+            duration: Duration::from_millis(1800),
+            status_code: Some(200),
+            body_length: 13,
+            header_fingerprint: ResponseHeaderFingerprint::from_response(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nServer: nginx-alt\r\nContent-Length: 13\r\n\r\n",
+            ),
+            is_connection_timeout: false,
+        };
+        assert!(control_indicates_false_positive(&attack, &control, None));
+    }
+
+    #[test]
+    fn followup_divergence_signals_keep_finding() {
+        let attack = VulnerabilityInfo {
+            status: "HTTP/1.1 200".into(),
+            status_code: Some(200),
+            duration: Duration::from_millis(2000),
+            body_length: 13,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        let control = ControlObservation {
+            duration: Duration::from_millis(1900), // very similar timing
+            status_code: Some(200),
+            body_length: 13,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        let followup = FollowupObservation {
+            diverging: 2,
+            total: 3,
+        };
+        // Without follow-up: timing similarity would reject as FP. With
+        // follow-up divergence: escape clause keeps the finding.
+        assert!(!control_indicates_false_positive(
+            &attack,
+            &control,
+            Some(&followup)
+        ));
+    }
+
+    #[test]
+    fn followup_no_divergence_lets_fp_rule_fire() {
+        let attack = VulnerabilityInfo {
+            status: "HTTP/1.1 200".into(),
+            status_code: Some(200),
+            duration: Duration::from_millis(2000),
+            body_length: 13,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        let control = ControlObservation {
+            duration: Duration::from_millis(1900),
+            status_code: Some(200),
+            body_length: 13,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        let followup = FollowupObservation {
+            diverging: 0,
+            total: 3,
+        };
+        // No follow-up divergence + similar timing → standard FP rule fires.
+        assert!(control_indicates_false_positive(
+            &attack,
+            &control,
+            Some(&followup)
+        ));
+    }
+
+    #[test]
+    fn followup_observation_reports_divergence() {
+        let f = FollowupObservation {
+            diverging: 1,
+            total: 3,
+        };
+        assert!(f.has_divergence());
+        let none = FollowupObservation {
+            diverging: 0,
+            total: 3,
+        };
+        assert!(!none.has_divergence());
+    }
+
+    #[test]
+    fn control_kept_when_bodies_diverge_despite_both_504() {
+        let attack = VulnerabilityInfo {
+            status: "HTTP/1.1 504".into(),
+            status_code: Some(504),
+            duration: Duration::from_millis(2000),
+            body_length: 100,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        let control = ControlObservation {
+            duration: Duration::from_millis(50),
+            status_code: Some(504),
+            body_length: 1000,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        // Both 504 would normally be FP, but body divergence overrides.
+        assert!(!control_indicates_false_positive(&attack, &control, None));
+    }
 }

--- a/tests/exploit_tests.rs
+++ b/tests/exploit_tests.rs
@@ -27,6 +27,7 @@ fn test_extract_vulnerability_context_clte() {
             payload: Some("POST / HTTP/1.1\r\nHost: example.com\r\n...".to_string()),
             confidence: None,
             detection_signals: Vec::new(),
+            diagnostics: Vec::new(),
         },
         CheckResult {
             check_type: "te-cl".to_string(),
@@ -40,6 +41,7 @@ fn test_extract_vulnerability_context_clte() {
             payload: None,
             confidence: None,
             detection_signals: Vec::new(),
+            diagnostics: Vec::new(),
         },
     ];
 
@@ -65,6 +67,7 @@ fn test_extract_vulnerability_context_tecl() {
         payload: Some("POST / HTTP/1.1\r\nHost: test.com\r\n...".to_string()),
         confidence: None,
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     }];
 
     let ctx = extract_vulnerability_context(&results);
@@ -88,6 +91,7 @@ fn test_extract_vulnerability_context_none() {
         payload: None,
         confidence: None,
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     }];
 
     let ctx = extract_vulnerability_context(&results);
@@ -109,6 +113,7 @@ fn test_extract_vulnerability_context_multiple_vulnerabilities() {
             payload: Some("CL.TE payload".to_string()),
             confidence: None,
             detection_signals: Vec::new(),
+            diagnostics: Vec::new(),
         },
         CheckResult {
             check_type: "te-cl".to_string(),
@@ -122,6 +127,7 @@ fn test_extract_vulnerability_context_multiple_vulnerabilities() {
             payload: Some("TE.CL payload".to_string()),
             confidence: None,
             detection_signals: Vec::new(),
+            diagnostics: Vec::new(),
         },
     ];
 
@@ -354,6 +360,7 @@ fn test_extract_vulnerability_context_no_payload() {
         payload: None, // No payload stored
         confidence: None,
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     }];
 
     let ctx = extract_vulnerability_context(&results);

--- a/tests/exploit_tests.rs
+++ b/tests/exploit_tests.rs
@@ -26,6 +26,7 @@ fn test_extract_vulnerability_context_clte() {
             timestamp: "2024-01-01T00:00:00Z".to_string(),
             payload: Some("POST / HTTP/1.1\r\nHost: example.com\r\n...".to_string()),
             confidence: None,
+            detection_signals: Vec::new(),
         },
         CheckResult {
             check_type: "te-cl".to_string(),
@@ -38,6 +39,7 @@ fn test_extract_vulnerability_context_clte() {
             timestamp: "2024-01-01T00:00:00Z".to_string(),
             payload: None,
             confidence: None,
+            detection_signals: Vec::new(),
         },
     ];
 
@@ -62,6 +64,7 @@ fn test_extract_vulnerability_context_tecl() {
         timestamp: "2024-01-01T00:00:00Z".to_string(),
         payload: Some("POST / HTTP/1.1\r\nHost: test.com\r\n...".to_string()),
         confidence: None,
+        detection_signals: Vec::new(),
     }];
 
     let ctx = extract_vulnerability_context(&results);
@@ -84,6 +87,7 @@ fn test_extract_vulnerability_context_none() {
         timestamp: "2024-01-01T00:00:00Z".to_string(),
         payload: None,
         confidence: None,
+        detection_signals: Vec::new(),
     }];
 
     let ctx = extract_vulnerability_context(&results);
@@ -104,6 +108,7 @@ fn test_extract_vulnerability_context_multiple_vulnerabilities() {
             timestamp: "2024-01-01T00:00:00Z".to_string(),
             payload: Some("CL.TE payload".to_string()),
             confidence: None,
+            detection_signals: Vec::new(),
         },
         CheckResult {
             check_type: "te-cl".to_string(),
@@ -116,6 +121,7 @@ fn test_extract_vulnerability_context_multiple_vulnerabilities() {
             timestamp: "2024-01-01T00:00:00Z".to_string(),
             payload: Some("TE.CL payload".to_string()),
             confidence: None,
+            detection_signals: Vec::new(),
         },
     ];
 
@@ -347,6 +353,7 @@ fn test_extract_vulnerability_context_no_payload() {
         timestamp: "2024-01-01T00:00:00Z".to_string(),
         payload: None, // No payload stored
         confidence: None,
+        detection_signals: Vec::new(),
     }];
 
     let ctx = extract_vulnerability_context(&results);

--- a/tests/main_tests.rs
+++ b/tests/main_tests.rs
@@ -207,6 +207,7 @@ async fn test_output_file_json_structure() {
             timestamp: Utc::now().to_rfc3339(),
             payload: None,
             confidence: None,
+            detection_signals: Vec::new(),
         }],
     };
 
@@ -267,6 +268,7 @@ async fn test_vulnerable_count_calculation() {
             timestamp: Utc::now().to_rfc3339(),
             payload: None,
             confidence: None,
+            detection_signals: Vec::new(),
         },
         CheckResult {
             check_type: "TE.CL".to_string(),
@@ -279,6 +281,7 @@ async fn test_vulnerable_count_calculation() {
             timestamp: Utc::now().to_rfc3339(),
             payload: None,
             confidence: None,
+            detection_signals: Vec::new(),
         },
         CheckResult {
             check_type: "H2C".to_string(),
@@ -291,6 +294,7 @@ async fn test_vulnerable_count_calculation() {
             timestamp: Utc::now().to_rfc3339(),
             payload: None,
             confidence: None,
+            detection_signals: Vec::new(),
         },
     ];
 
@@ -632,6 +636,7 @@ async fn test_results_aggregation() {
             timestamp: Utc::now().to_rfc3339(),
             payload: None,
             confidence: None,
+            detection_signals: Vec::new(),
         },
         CheckResult {
             check_type: "TE.CL".to_string(),
@@ -644,6 +649,7 @@ async fn test_results_aggregation() {
             timestamp: Utc::now().to_rfc3339(),
             payload: None,
             confidence: None,
+            detection_signals: Vec::new(),
         },
     ];
 

--- a/tests/main_tests.rs
+++ b/tests/main_tests.rs
@@ -208,6 +208,7 @@ async fn test_output_file_json_structure() {
             payload: None,
             confidence: None,
             detection_signals: Vec::new(),
+            diagnostics: Vec::new(),
         }],
     };
 
@@ -269,6 +270,7 @@ async fn test_vulnerable_count_calculation() {
             payload: None,
             confidence: None,
             detection_signals: Vec::new(),
+            diagnostics: Vec::new(),
         },
         CheckResult {
             check_type: "TE.CL".to_string(),
@@ -282,6 +284,7 @@ async fn test_vulnerable_count_calculation() {
             payload: None,
             confidence: None,
             detection_signals: Vec::new(),
+            diagnostics: Vec::new(),
         },
         CheckResult {
             check_type: "H2C".to_string(),
@@ -295,6 +298,7 @@ async fn test_vulnerable_count_calculation() {
             payload: None,
             confidence: None,
             detection_signals: Vec::new(),
+            diagnostics: Vec::new(),
         },
     ];
 
@@ -637,6 +641,7 @@ async fn test_results_aggregation() {
             payload: None,
             confidence: None,
             detection_signals: Vec::new(),
+            diagnostics: Vec::new(),
         },
         CheckResult {
             check_type: "TE.CL".to_string(),
@@ -650,6 +655,7 @@ async fn test_results_aggregation() {
             payload: None,
             confidence: None,
             detection_signals: Vec::new(),
+            diagnostics: Vec::new(),
         },
     ];
 

--- a/tests/model_tests.rs
+++ b/tests/model_tests.rs
@@ -30,6 +30,7 @@ fn create_test_check_result(
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         payload: None,
         confidence: None,
+        detection_signals: Vec::new(),
     }
 }
 
@@ -147,6 +148,7 @@ fn test_check_result_zero_duration() {
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         payload: None,
         confidence: None,
+        detection_signals: Vec::new(),
     };
 
     assert_eq!(result.normal_duration_ms, 0);
@@ -167,6 +169,7 @@ fn test_check_result_special_characters() {
         timestamp: "2024-01-01T12:00:00+00:00".to_string(),
         payload: None,
         confidence: Some(Confidence::High),
+        detection_signals: Vec::new(),
     };
 
     let json = serde_json::to_string(&result).expect("Should serialize");
@@ -189,6 +192,7 @@ fn test_check_result_serialization_vulnerable() {
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         payload: None,
         confidence: Some(Confidence::Medium),
+        detection_signals: Vec::new(),
     };
 
     let json = serde_json::to_string(&result).expect("Failed to serialize");
@@ -235,6 +239,7 @@ fn test_check_result_clone() {
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         payload: None,
         confidence: Some(Confidence::High),
+        detection_signals: Vec::new(),
     };
 
     let cloned = result.clone();
@@ -258,6 +263,7 @@ fn test_scan_results_creation() {
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         payload: None,
         confidence: Some(Confidence::High),
+        detection_signals: Vec::new(),
     };
 
     let check2 = CheckResult {
@@ -271,6 +277,7 @@ fn test_scan_results_creation() {
         timestamp: "2024-01-01T12:00:01Z".to_string(),
         payload: None,
         confidence: None,
+        detection_signals: Vec::new(),
     };
 
     let scan_results = ScanResults {
@@ -301,6 +308,7 @@ fn test_scan_results_serialization() {
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         payload: None,
         confidence: Some(Confidence::High),
+        detection_signals: Vec::new(),
     };
 
     let scan_results = ScanResults {
@@ -380,6 +388,7 @@ fn test_scan_results_multiple_checks() {
             timestamp: "2024-01-01T12:00:00Z".to_string(),
             payload: None,
             confidence: Some(Confidence::High),
+            detection_signals: Vec::new(),
         },
         CheckResult {
             check_type: "TE.CL".to_string(),
@@ -392,6 +401,7 @@ fn test_scan_results_multiple_checks() {
             timestamp: "2024-01-01T12:00:01Z".to_string(),
             payload: None,
             confidence: None,
+            detection_signals: Vec::new(),
         },
         CheckResult {
             check_type: "TE.TE".to_string(),
@@ -404,6 +414,7 @@ fn test_scan_results_multiple_checks() {
             timestamp: "2024-01-01T12:00:02Z".to_string(),
             payload: None,
             confidence: Some(Confidence::Low),
+            detection_signals: Vec::new(),
         },
     ];
 
@@ -437,6 +448,7 @@ fn test_check_result_different_check_types() {
             timestamp: "2024-01-01T12:00:00Z".to_string(),
             payload: None,
             confidence: None,
+            detection_signals: Vec::new(),
         };
 
         assert_eq!(result.check_type, check_type);
@@ -457,6 +469,7 @@ fn test_check_result_timeout_scenarios() {
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         payload: None,
         confidence: Some(Confidence::High),
+        detection_signals: Vec::new(),
     };
 
     assert!(result1.attack_status.as_ref().unwrap().contains("504"));
@@ -473,6 +486,7 @@ fn test_check_result_timeout_scenarios() {
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         payload: None,
         confidence: Some(Confidence::Low),
+        detection_signals: Vec::new(),
     };
 
     assert_eq!(
@@ -497,6 +511,7 @@ fn test_payload_stored_in_vulnerable_result() {
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         payload: Some(payload_content.to_string()),
         confidence: Some(Confidence::Medium),
+        detection_signals: Vec::new(),
     };
 
     assert!(result.vulnerable);
@@ -518,6 +533,7 @@ fn test_payload_is_none_for_non_vulnerable() {
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         payload: None,
         confidence: None,
+        detection_signals: Vec::new(),
     };
 
     assert!(!result.vulnerable);
@@ -538,6 +554,7 @@ fn test_payload_serialization_with_payload() {
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         payload: Some("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n".to_string()),
         confidence: Some(Confidence::Low),
+        detection_signals: Vec::new(),
     };
 
     let json = serde_json::to_string(&result).expect("Failed to serialize");
@@ -561,6 +578,7 @@ fn test_payload_serialization_without_payload() {
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         payload: None,
         confidence: None,
+        detection_signals: Vec::new(),
     };
 
     let json = serde_json::to_string(&result).expect("Failed to serialize");
@@ -587,6 +605,7 @@ fn test_confidence_serialization() {
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         payload: None,
         confidence: Some(Confidence::High),
+        detection_signals: Vec::new(),
     };
     let json = serde_json::to_string(&result).expect("Failed to serialize");
     assert!(json.contains("\"confidence\":\"high\""));
@@ -594,6 +613,7 @@ fn test_confidence_serialization() {
     // Test Medium
     let result = CheckResult {
         confidence: Some(Confidence::Medium),
+        detection_signals: Vec::new(),
         ..result.clone()
     };
     let json = serde_json::to_string(&result).expect("Failed to serialize");
@@ -602,6 +622,7 @@ fn test_confidence_serialization() {
     // Test Low
     let result = CheckResult {
         confidence: Some(Confidence::Low),
+        detection_signals: Vec::new(),
         ..result
     };
     let json = serde_json::to_string(&result).expect("Failed to serialize");
@@ -621,6 +642,7 @@ fn test_confidence_skip_when_none() {
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         payload: None,
         confidence: None,
+        detection_signals: Vec::new(),
     };
     let json = serde_json::to_string(&result).expect("Failed to serialize");
     assert!(!json.contains("confidence"));

--- a/tests/model_tests.rs
+++ b/tests/model_tests.rs
@@ -31,6 +31,7 @@ fn create_test_check_result(
         payload: None,
         confidence: None,
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     }
 }
 
@@ -149,6 +150,7 @@ fn test_check_result_zero_duration() {
         payload: None,
         confidence: None,
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     };
 
     assert_eq!(result.normal_duration_ms, 0);
@@ -170,6 +172,7 @@ fn test_check_result_special_characters() {
         payload: None,
         confidence: Some(Confidence::High),
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     };
 
     let json = serde_json::to_string(&result).expect("Should serialize");
@@ -193,6 +196,7 @@ fn test_check_result_serialization_vulnerable() {
         payload: None,
         confidence: Some(Confidence::Medium),
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     };
 
     let json = serde_json::to_string(&result).expect("Failed to serialize");
@@ -240,6 +244,7 @@ fn test_check_result_clone() {
         payload: None,
         confidence: Some(Confidence::High),
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     };
 
     let cloned = result.clone();
@@ -264,6 +269,7 @@ fn test_scan_results_creation() {
         payload: None,
         confidence: Some(Confidence::High),
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     };
 
     let check2 = CheckResult {
@@ -278,6 +284,7 @@ fn test_scan_results_creation() {
         payload: None,
         confidence: None,
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     };
 
     let scan_results = ScanResults {
@@ -309,6 +316,7 @@ fn test_scan_results_serialization() {
         payload: None,
         confidence: Some(Confidence::High),
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     };
 
     let scan_results = ScanResults {
@@ -389,6 +397,7 @@ fn test_scan_results_multiple_checks() {
             payload: None,
             confidence: Some(Confidence::High),
             detection_signals: Vec::new(),
+            diagnostics: Vec::new(),
         },
         CheckResult {
             check_type: "TE.CL".to_string(),
@@ -402,6 +411,7 @@ fn test_scan_results_multiple_checks() {
             payload: None,
             confidence: None,
             detection_signals: Vec::new(),
+            diagnostics: Vec::new(),
         },
         CheckResult {
             check_type: "TE.TE".to_string(),
@@ -415,6 +425,7 @@ fn test_scan_results_multiple_checks() {
             payload: None,
             confidence: Some(Confidence::Low),
             detection_signals: Vec::new(),
+            diagnostics: Vec::new(),
         },
     ];
 
@@ -449,6 +460,7 @@ fn test_check_result_different_check_types() {
             payload: None,
             confidence: None,
             detection_signals: Vec::new(),
+            diagnostics: Vec::new(),
         };
 
         assert_eq!(result.check_type, check_type);
@@ -470,6 +482,7 @@ fn test_check_result_timeout_scenarios() {
         payload: None,
         confidence: Some(Confidence::High),
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     };
 
     assert!(result1.attack_status.as_ref().unwrap().contains("504"));
@@ -487,6 +500,7 @@ fn test_check_result_timeout_scenarios() {
         payload: None,
         confidence: Some(Confidence::Low),
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     };
 
     assert_eq!(
@@ -512,6 +526,7 @@ fn test_payload_stored_in_vulnerable_result() {
         payload: Some(payload_content.to_string()),
         confidence: Some(Confidence::Medium),
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     };
 
     assert!(result.vulnerable);
@@ -534,6 +549,7 @@ fn test_payload_is_none_for_non_vulnerable() {
         payload: None,
         confidence: None,
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     };
 
     assert!(!result.vulnerable);
@@ -555,6 +571,7 @@ fn test_payload_serialization_with_payload() {
         payload: Some("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n".to_string()),
         confidence: Some(Confidence::Low),
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     };
 
     let json = serde_json::to_string(&result).expect("Failed to serialize");
@@ -579,6 +596,7 @@ fn test_payload_serialization_without_payload() {
         payload: None,
         confidence: None,
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     };
 
     let json = serde_json::to_string(&result).expect("Failed to serialize");
@@ -606,6 +624,7 @@ fn test_confidence_serialization() {
         payload: None,
         confidence: Some(Confidence::High),
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     };
     let json = serde_json::to_string(&result).expect("Failed to serialize");
     assert!(json.contains("\"confidence\":\"high\""));
@@ -614,6 +633,7 @@ fn test_confidence_serialization() {
     let result = CheckResult {
         confidence: Some(Confidence::Medium),
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
         ..result.clone()
     };
     let json = serde_json::to_string(&result).expect("Failed to serialize");
@@ -623,6 +643,7 @@ fn test_confidence_serialization() {
     let result = CheckResult {
         confidence: Some(Confidence::Low),
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
         ..result
     };
     let json = serde_json::to_string(&result).expect("Failed to serialize");
@@ -643,6 +664,7 @@ fn test_confidence_skip_when_none() {
         payload: None,
         confidence: None,
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     };
     let json = serde_json::to_string(&result).expect("Failed to serialize");
     assert!(!json.contains("confidence"));

--- a/tests/output_tests.rs
+++ b/tests/output_tests.rs
@@ -24,6 +24,7 @@ fn test_save_results_to_file_creates_json() {
         payload: Some("test payload".to_string()),
         confidence: None,
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     }];
 
     let result = save_results_to_file(output_path, "http://example.com", "GET", results, &None);
@@ -66,6 +67,7 @@ fn test_save_results_to_file_with_fingerprint() {
         payload: None,
         confidence: None,
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     }];
 
     let result = save_results_to_file(

--- a/tests/output_tests.rs
+++ b/tests/output_tests.rs
@@ -23,6 +23,7 @@ fn test_save_results_to_file_creates_json() {
         timestamp: "2024-01-01T00:00:00Z".to_string(),
         payload: Some("test payload".to_string()),
         confidence: None,
+        detection_signals: Vec::new(),
     }];
 
     let result = save_results_to_file(output_path, "http://example.com", "GET", results, &None);
@@ -64,6 +65,7 @@ fn test_save_results_to_file_with_fingerprint() {
         timestamp: "2024-01-01T00:00:00Z".to_string(),
         payload: None,
         confidence: None,
+        detection_signals: Vec::new(),
     }];
 
     let result = save_results_to_file(
@@ -92,8 +94,7 @@ fn test_save_results_to_file_empty_results() {
     let output_file = temp_dir.join("smugglex_test_output_empty.json");
     let output_path = output_file.to_str().unwrap();
 
-    let result =
-        save_results_to_file(output_path, "http://example.com", "GET", Vec::new(), &None);
+    let result = save_results_to_file(output_path, "http://example.com", "GET", Vec::new(), &None);
     assert!(result.is_ok());
 
     let content = fs::read_to_string(output_path).unwrap();

--- a/tests/payloads_tests.rs
+++ b/tests/payloads_tests.rs
@@ -117,6 +117,7 @@ fn test_check_result_serialization() {
         payload: None,
         confidence: None,
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     };
 
     let json = serde_json::to_string(&result);

--- a/tests/payloads_tests.rs
+++ b/tests/payloads_tests.rs
@@ -116,6 +116,7 @@ fn test_check_result_serialization() {
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         payload: None,
         confidence: None,
+        detection_signals: Vec::new(),
     };
 
     let json = serde_json::to_string(&result);

--- a/tests/scanner_tests.rs
+++ b/tests/scanner_tests.rs
@@ -46,7 +46,10 @@ fn test_baseline_count_constant() {
 
 #[test]
 fn test_confirmation_retries_constant() {
-    assert_eq!(CONFIRMATION_RETRIES, 2, "Confirmation retries should be 2");
+    assert_eq!(
+        CONFIRMATION_RETRIES, 3,
+        "Confirmation retries should be 3 (strict-majority threshold)"
+    );
 }
 
 // ========== Progress Message Format Tests ==========
@@ -333,6 +336,7 @@ fn test_check_result_vulnerable_state() {
         timestamp: Utc::now().to_rfc3339(),
         payload: None,
         confidence: None,
+        detection_signals: Vec::new(),
     };
 
     assert!(result.vulnerable);
@@ -354,6 +358,7 @@ fn test_check_result_not_vulnerable_state() {
         timestamp: Utc::now().to_rfc3339(),
         payload: None,
         confidence: None,
+        detection_signals: Vec::new(),
     };
 
     assert!(!result.vulnerable);
@@ -1262,5 +1267,736 @@ async fn test_confirmed_vulnerability_medium_confidence() {
         check_result.confidence,
         Some(smugglex::model::Confidence::Medium),
         "Timing-only anomaly should yield Medium confidence"
+    );
+}
+
+// ========== Additional FP/FN Reduction Tests ==========
+
+/// Single transient 504 in baseline should NOT disable the status-code signal.
+/// (Majority of baseline is still 200, so 504 attack remains a smuggling signal.)
+#[tokio::test]
+async fn test_single_baseline_504_does_not_disable_signal() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let host = addr.ip().to_string();
+    let port = addr.port();
+
+    let handle = tokio::spawn(async move {
+        let request_count = Arc::new(AtomicUsize::new(0));
+        loop {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                let count = request_count.clone();
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 4096];
+                    let _ = socket.read(&mut buf).await;
+
+                    let n = count.fetch_add(1, Ordering::SeqCst) + 1;
+
+                    // Baseline 1 = 504 (single spurious), baseline 2,3 = 200 OK.
+                    // Attack + confirmations (n >= 4) = 504.
+                    let response = if n == 1 || n > DEFAULT_BASELINE_COUNT {
+                        "HTTP/1.1 504 Gateway Timeout\r\nContent-Length: 0\r\n\r\n"
+                    } else {
+                        "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nHello, World!"
+                    };
+                    let _ = socket.write_all(response.as_bytes()).await;
+                });
+            }
+        }
+    });
+
+    let pb = ProgressBar::new_spinner();
+    pb.finish_and_clear();
+
+    let attack_requests = vec![format!(
+        "GET / HTTP/1.1\r\nHost: {}\r\nContent-Length: 5\r\n\r\ntest1",
+        host
+    )];
+
+    let result = run_checks_for_type(CheckParams {
+        pb: &pb,
+        check_name: "CL.TE",
+        host: &host,
+        port,
+        path: "/",
+        attack_requests,
+        timeout: 5,
+        verbose: false,
+        use_tls: false,
+        export_dir: None,
+        current_check: 1,
+        total_checks: 1,
+        delay: 0,
+        baseline_count: DEFAULT_BASELINE_COUNT,
+    })
+    .await;
+
+    handle.abort();
+
+    assert!(result.is_ok());
+    let check_result = result.unwrap();
+    assert!(
+        check_result.vulnerable,
+        "A single transient 504 in baseline should not suppress detection"
+    );
+}
+
+/// `baseline_count: 0` must not panic; it should be clamped to a single baseline probe.
+#[tokio::test]
+async fn test_baseline_count_zero_does_not_panic() {
+    let (host, port, handle) = start_normal_server().await;
+
+    let pb = ProgressBar::new_spinner();
+    pb.finish_and_clear();
+
+    let attack_requests = vec![format!("GET / HTTP/1.1\r\nHost: {}\r\n\r\n", host)];
+
+    let result = run_checks_for_type(CheckParams {
+        pb: &pb,
+        check_name: "CL.TE",
+        host: &host,
+        port,
+        path: "/",
+        attack_requests,
+        timeout: 5,
+        verbose: false,
+        use_tls: false,
+        export_dir: None,
+        current_check: 1,
+        total_checks: 1,
+        delay: 0,
+        baseline_count: 0,
+    })
+    .await;
+
+    handle.abort();
+    assert!(
+        result.is_ok(),
+        "baseline_count=0 must be clamped, not panic"
+    );
+}
+
+/// Confirmation requires strict majority (>N/2) for status/timing signals.
+/// With 3 retries: only 1 of 3 reproducing must NOT confirm.
+#[tokio::test]
+async fn test_minority_confirmation_not_flagged() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let host = addr.ip().to_string();
+    let port = addr.port();
+
+    let handle = tokio::spawn(async move {
+        let request_count = Arc::new(AtomicUsize::new(0));
+        loop {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                let count = request_count.clone();
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 4096];
+                    let _ = socket.read(&mut buf).await;
+
+                    let n = count.fetch_add(1, Ordering::SeqCst) + 1;
+
+                    // Baseline 1..=3: 200 OK
+                    // First attack (n=4): 504  -> initial detection
+                    // Confirmations (n=5,6,7): only n=5 reproduces 504; n=6,7 return 200
+                    // That's 1/3 reproduced -> minority -> NOT confirmed.
+                    let response = if n <= DEFAULT_BASELINE_COUNT {
+                        "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nHello, World!"
+                    } else if n == DEFAULT_BASELINE_COUNT + 1 || n == DEFAULT_BASELINE_COUNT + 2 {
+                        "HTTP/1.1 504 Gateway Timeout\r\nContent-Length: 0\r\n\r\n"
+                    } else {
+                        "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nHello, World!"
+                    };
+                    let _ = socket.write_all(response.as_bytes()).await;
+                });
+            }
+        }
+    });
+
+    let pb = ProgressBar::new_spinner();
+    pb.finish_and_clear();
+
+    let attack_requests = vec![format!(
+        "GET / HTTP/1.1\r\nHost: {}\r\nContent-Length: 5\r\n\r\ntest1",
+        host
+    )];
+
+    let result = run_checks_for_type(CheckParams {
+        pb: &pb,
+        check_name: "CL.TE",
+        host: &host,
+        port,
+        path: "/",
+        attack_requests,
+        timeout: 5,
+        verbose: false,
+        use_tls: false,
+        export_dir: None,
+        current_check: 1,
+        total_checks: 1,
+        delay: 0,
+        baseline_count: DEFAULT_BASELINE_COUNT,
+    })
+    .await;
+
+    handle.abort();
+    assert!(result.is_ok());
+    let check_result = result.unwrap();
+    assert!(
+        !check_result.vulnerable,
+        "Minority reproduction (1/3) must not confirm vulnerability"
+    );
+}
+
+// ========== Differential Control Comparison Tests ==========
+
+/// Mock server that is uniformly slow on every request after baseline,
+/// regardless of whether the request carries smuggling artifacts.
+/// This simulates a backend with naturally slow POST handling — the canonical
+/// "slow heavy POST" false-positive scenario.
+async fn start_uniformly_slow_post_server() -> (String, u16, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let host = addr.ip().to_string();
+    let port = addr.port();
+
+    let handle = tokio::spawn(async move {
+        let request_count = Arc::new(AtomicUsize::new(0));
+        loop {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                let count = request_count.clone();
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 8192];
+                    let _ = socket.read(&mut buf).await;
+                    let n = count.fetch_add(1, Ordering::SeqCst) + 1;
+
+                    // Baseline GETs (1..=3) are fast.
+                    // Every post-baseline request (attack, retries, control) is slow.
+                    if n > DEFAULT_BASELINE_COUNT {
+                        tokio::time::sleep(Duration::from_millis(2000)).await;
+                    }
+                    let response = "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nHello, World!";
+                    let _ = socket.write_all(response.as_bytes()).await;
+                });
+            }
+        }
+    });
+
+    (host, port, handle)
+}
+
+/// Mock server that is slow ONLY when the request carries a Transfer-Encoding
+/// header. This simulates a real smuggling-vulnerable backend whose desync is
+/// triggered by the TE header, while shape-matched non-TE requests respond
+/// promptly.
+async fn start_te_specific_slow_server() -> (String, u16, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let host = addr.ip().to_string();
+    let port = addr.port();
+
+    let handle = tokio::spawn(async move {
+        let request_count = Arc::new(AtomicUsize::new(0));
+        loop {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                let count = request_count.clone();
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 8192];
+                    let n_read = socket.read(&mut buf).await.unwrap_or(0);
+                    let body_str = String::from_utf8_lossy(&buf[..n_read]).to_ascii_lowercase();
+                    let n = count.fetch_add(1, Ordering::SeqCst) + 1;
+
+                    let has_te = body_str.contains("transfer-encoding");
+                    if n > DEFAULT_BASELINE_COUNT && has_te {
+                        tokio::time::sleep(Duration::from_millis(2000)).await;
+                    }
+                    let response = "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nHello, World!";
+                    let _ = socket.write_all(response.as_bytes()).await;
+                });
+            }
+        }
+    });
+
+    (host, port, handle)
+}
+
+/// FP rejection: a TE-carrying payload against a backend that is slow on EVERY
+/// POST should be rejected via differential control comparison — the stripped
+/// control also takes ~2s, proving the slowness is not caused by the smuggling
+/// artifacts.
+#[tokio::test]
+async fn test_uniform_slow_backend_rejected_via_control() {
+    let (host, port, handle) = start_uniformly_slow_post_server().await;
+
+    let pb = ProgressBar::new_spinner();
+    pb.finish_and_clear();
+
+    // Realistic CL.TE-style payload with Transfer-Encoding header — triggers
+    // the control-comparison codepath.
+    let attack_requests = vec![format!(
+        "POST / HTTP/1.1\r\nHost: {}\r\nTransfer-Encoding: chunked\r\nContent-Length: 6\r\n\r\n0\r\n\r\nG",
+        host
+    )];
+
+    let result = run_checks_for_type(CheckParams {
+        pb: &pb,
+        check_name: "CL.TE",
+        host: &host,
+        port,
+        path: "/",
+        attack_requests,
+        timeout: 5,
+        verbose: false,
+        use_tls: false,
+        export_dir: None,
+        current_check: 1,
+        total_checks: 1,
+        delay: 0,
+        baseline_count: DEFAULT_BASELINE_COUNT,
+    })
+    .await;
+
+    handle.abort();
+    let check_result = result.unwrap();
+    assert!(
+        !check_result.vulnerable,
+        "Uniform slow backend should be rejected as FP via control comparison"
+    );
+}
+
+/// True positive: a TE-carrying payload against a TE-specific slow backend must
+/// still be flagged — the control (no TE) responds quickly, so the comparison
+/// confirms smuggling rather than rejecting it.
+#[tokio::test]
+async fn test_te_specific_slow_backend_still_detected() {
+    let (host, port, handle) = start_te_specific_slow_server().await;
+
+    let pb = ProgressBar::new_spinner();
+    pb.finish_and_clear();
+
+    let attack_requests = vec![format!(
+        "POST / HTTP/1.1\r\nHost: {}\r\nTransfer-Encoding: chunked\r\nContent-Length: 6\r\n\r\n0\r\n\r\nG",
+        host
+    )];
+
+    let result = run_checks_for_type(CheckParams {
+        pb: &pb,
+        check_name: "CL.TE",
+        host: &host,
+        port,
+        path: "/",
+        attack_requests,
+        timeout: 5,
+        verbose: false,
+        use_tls: false,
+        export_dir: None,
+        current_check: 1,
+        total_checks: 1,
+        delay: 0,
+        baseline_count: DEFAULT_BASELINE_COUNT,
+    })
+    .await;
+
+    handle.abort();
+    let check_result = result.unwrap();
+    assert!(
+        check_result.vulnerable,
+        "TE-specific slow backend must remain detected after control comparison"
+    );
+}
+
+/// Noise-aware threshold: a noisy baseline whose max approaches the attack
+/// timing should suppress detection — the attack must beat both the relative
+/// multiplier and the worst-baseline-plus-buffer floor.
+#[tokio::test]
+async fn test_noisy_baseline_suppresses_borderline_attack() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let host = addr.ip().to_string();
+    let port = addr.port();
+
+    let handle = tokio::spawn(async move {
+        let request_count = Arc::new(AtomicUsize::new(0));
+        loop {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                let count = request_count.clone();
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 8192];
+                    let _ = socket.read(&mut buf).await;
+                    let n = count.fetch_add(1, Ordering::SeqCst) + 1;
+
+                    // Baseline: one slow (1500ms) + two fast probes. median is fast
+                    // but max=1500ms, so the noise-aware threshold is at least
+                    // 1500+500=2000ms. A 1200ms "attack" must NOT trigger.
+                    if n == 1 {
+                        tokio::time::sleep(Duration::from_millis(1500)).await;
+                    } else if n > DEFAULT_BASELINE_COUNT {
+                        tokio::time::sleep(Duration::from_millis(1200)).await;
+                    }
+                    let response = "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nHello, World!";
+                    let _ = socket.write_all(response.as_bytes()).await;
+                });
+            }
+        }
+    });
+
+    let pb = ProgressBar::new_spinner();
+    pb.finish_and_clear();
+
+    let attack_requests = vec![format!(
+        "GET / HTTP/1.1\r\nHost: {}\r\nContent-Length: 5\r\n\r\ntest1",
+        host
+    )];
+
+    let result = run_checks_for_type(CheckParams {
+        pb: &pb,
+        check_name: "CL.TE",
+        host: &host,
+        port,
+        path: "/",
+        attack_requests,
+        timeout: 5,
+        verbose: false,
+        use_tls: false,
+        export_dir: None,
+        current_check: 1,
+        total_checks: 1,
+        delay: 0,
+        baseline_count: DEFAULT_BASELINE_COUNT,
+    })
+    .await;
+
+    handle.abort();
+    let check_result = result.unwrap();
+    assert!(
+        !check_result.vulnerable,
+        "Borderline attack within noisy baseline range must not flag"
+    );
+}
+
+/// Body-divergence escape clause: a TE-carrying attack against a backend that
+/// is uniformly slow (would normally be rejected as FP via control timing
+/// similarity) MUST still be flagged when the attack response body differs
+/// substantially from the control body — that body change is the canonical
+/// smuggling desync signature and overrides the timing similarity rule.
+#[tokio::test]
+async fn test_body_divergence_overrides_control_timing_similarity() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let host = addr.ip().to_string();
+    let port = addr.port();
+
+    let handle = tokio::spawn(async move {
+        loop {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 8192];
+                    let n_read = socket.read(&mut buf).await.unwrap_or(0);
+                    let req = String::from_utf8_lossy(&buf[..n_read]).to_ascii_lowercase();
+
+                    // Backend is slow whenever the request shape carries a
+                    // non-empty body (Transfer-Encoding present, or
+                    // Content-Length != 0). CL:0 method-matched baselines run
+                    // fast, attack (TE) and control (CL=body_len padding) both
+                    // run slow — this is the scenario the body-divergence
+                    // escape clause exists for.
+                    let has_te = req.contains("transfer-encoding");
+                    let has_cl_nonzero = req.lines().any(|l| {
+                        let lt = l.trim_start();
+                        lt.starts_with("content-length:")
+                            && !lt
+                                .trim_start_matches("content-length:")
+                                .trim()
+                                .starts_with('0')
+                    });
+                    if has_te || has_cl_nonzero {
+                        tokio::time::sleep(Duration::from_millis(2000)).await;
+                    }
+
+                    // TE-carrying request: small error-shaped body (simulating
+                    // backend desync where the smuggled chunk was misinterpreted).
+                    // Non-TE request (baseline / control): full normal response.
+                    let body = if has_te {
+                        "ERR: bad chunk"
+                    } else {
+                        "Hello, World! This is a normal substantial response body that exceeds the body-divergence minimum size threshold so the heuristic kicks in."
+                    };
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                });
+            }
+        }
+    });
+
+    let pb = ProgressBar::new_spinner();
+    pb.finish_and_clear();
+
+    let attack_requests = vec![format!(
+        "POST / HTTP/1.1\r\nHost: {}\r\nTransfer-Encoding: chunked\r\nContent-Length: 6\r\n\r\n0\r\n\r\nG",
+        host
+    )];
+
+    let result = run_checks_for_type(CheckParams {
+        pb: &pb,
+        check_name: "CL.TE",
+        host: &host,
+        port,
+        path: "/",
+        attack_requests,
+        timeout: 5,
+        verbose: false,
+        use_tls: false,
+        export_dir: None,
+        current_check: 1,
+        total_checks: 1,
+        delay: 0,
+        baseline_count: DEFAULT_BASELINE_COUNT,
+    })
+    .await;
+
+    handle.abort();
+    let check_result = result.unwrap();
+    assert!(
+        check_result.vulnerable,
+        "Body divergence between attack and control must escape the timing-similarity FP rule"
+    );
+    // Detection signals should record body divergence as the corroborating signal.
+    assert!(
+        check_result
+            .detection_signals
+            .iter()
+            .any(|s| s == "body_divergence_vs_control"),
+        "Expected body_divergence_vs_control in signals, got: {:?}",
+        check_result.detection_signals
+    );
+}
+
+/// Method-matched baseline: a backend where GET responses are fast but POST
+/// responses are intrinsically slow (~1.4s) must NOT flag a 1.5s POST attack —
+/// the method-matched baseline lifts the noise floor so borderline POSTs don't
+/// look anomalous against the cheap GET baseline.
+#[tokio::test]
+async fn test_method_matched_baseline_suppresses_post_only_slowness() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let host = addr.ip().to_string();
+    let port = addr.port();
+
+    let handle = tokio::spawn(async move {
+        loop {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 8192];
+                    let n_read = socket.read(&mut buf).await.unwrap_or(0);
+                    let req = String::from_utf8_lossy(&buf[..n_read]);
+                    let method = req.split_whitespace().next().unwrap_or("");
+                    // GET: fast. POST (and any non-GET): always ~1400ms.
+                    if !method.eq_ignore_ascii_case("GET") {
+                        tokio::time::sleep(Duration::from_millis(1400)).await;
+                    }
+                    let response = "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nHello, World!";
+                    let _ = socket.write_all(response.as_bytes()).await;
+                });
+            }
+        }
+    });
+
+    let pb = ProgressBar::new_spinner();
+    pb.finish_and_clear();
+
+    // POST attack that takes ~1400ms — same as POST baseline.
+    let attack_requests = vec![format!(
+        "POST / HTTP/1.1\r\nHost: {}\r\nContent-Length: 5\r\n\r\ntest1",
+        host
+    )];
+
+    let result = run_checks_for_type(CheckParams {
+        pb: &pb,
+        check_name: "CL.TE",
+        host: &host,
+        port,
+        path: "/",
+        attack_requests,
+        timeout: 5,
+        verbose: false,
+        use_tls: false,
+        export_dir: None,
+        current_check: 1,
+        total_checks: 1,
+        delay: 0,
+        baseline_count: DEFAULT_BASELINE_COUNT,
+    })
+    .await;
+
+    handle.abort();
+    let check_result = result.unwrap();
+    assert!(
+        !check_result.vulnerable,
+        "POST-intrinsic slowness must be absorbed by method-matched baseline, not flagged"
+    );
+}
+
+/// Post-attack follow-up GET divergence: the mock backend changes its baseline
+/// GET response shape AFTER the attack (simulating a poisoned proxy↔backend
+/// channel). The detection must record `followup_divergence` and survive even
+/// when timing/body/header similarity would otherwise let the FP rule fire.
+#[tokio::test]
+async fn test_followup_divergence_signal_recorded() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let host = addr.ip().to_string();
+    let port = addr.port();
+
+    let handle = tokio::spawn(async move {
+        let request_count = Arc::new(AtomicUsize::new(0));
+        loop {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                let count = request_count.clone();
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 8192];
+                    let n_read = socket.read(&mut buf).await.unwrap_or(0);
+                    let req = String::from_utf8_lossy(&buf[..n_read]).to_ascii_lowercase();
+                    let has_te = req.contains("transfer-encoding");
+                    let n = count.fetch_add(1, Ordering::SeqCst) + 1;
+
+                    // Baseline GETs return normal substantial body.
+                    // TE-carrying attack: slow + small body (desync signature).
+                    // Follow-up GETs (after the attack window) return a
+                    // significantly different body — simulating a backend
+                    // whose connection state was poisoned by the smuggled
+                    // prefix.
+                    //
+                    // Request order (POST attack triggers R8 method-matched
+                    // POST baseline before the attack loop):
+                    //   1..=3   GET baseline probes
+                    //   4..=6   method-matched POST baselines (CL:0, no TE)
+                    //   7       attack (with TE)
+                    //   8..=10  3 confirmation retries (with TE)
+                    //  11..=12  2 differential control samples (POST padded)
+                    //  13..=15  3 follow-up GETs (post-desync window)
+                    let is_followup = (13..=15).contains(&n);
+                    if has_te {
+                        tokio::time::sleep(Duration::from_millis(2000)).await;
+                        let body = "ERR";
+                        let response = format!(
+                            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                            body.len(),
+                            body
+                        );
+                        let _ = socket.write_all(response.as_bytes()).await;
+                    } else if is_followup {
+                        // Post-desync: body diverges substantially from baseline.
+                        let body = "DESYNC-MARKER-LONG-RESPONSE-PAYLOAD-SUFFICIENT-FOR-DIVERGENCE";
+                        let response = format!(
+                            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                            body.len(),
+                            body
+                        );
+                        let _ = socket.write_all(response.as_bytes()).await;
+                    } else {
+                        let body = "Hello, World!";
+                        let response = format!(
+                            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                            body.len(),
+                            body
+                        );
+                        let _ = socket.write_all(response.as_bytes()).await;
+                    }
+                });
+            }
+        }
+    });
+
+    let pb = ProgressBar::new_spinner();
+    pb.finish_and_clear();
+
+    let attack_requests = vec![format!(
+        "POST / HTTP/1.1\r\nHost: {}\r\nTransfer-Encoding: chunked\r\nContent-Length: 6\r\n\r\n0\r\n\r\nG",
+        host
+    )];
+
+    let result = run_checks_for_type(CheckParams {
+        pb: &pb,
+        check_name: "CL.TE",
+        host: &host,
+        port,
+        path: "/",
+        attack_requests,
+        timeout: 5,
+        verbose: false,
+        use_tls: false,
+        export_dir: None,
+        current_check: 1,
+        total_checks: 1,
+        delay: 0,
+        baseline_count: DEFAULT_BASELINE_COUNT,
+    })
+    .await;
+
+    handle.abort();
+    let check_result = result.unwrap();
+    assert!(
+        check_result.vulnerable,
+        "Vulnerability with follow-up desync must be reported"
+    );
+    assert!(
+        check_result
+            .detection_signals
+            .iter()
+            .any(|s| s.starts_with("followup_divergence")),
+        "Expected followup_divergence signal, got: {:?}",
+        check_result.detection_signals
+    );
+}
+
+/// A confirmed timing-only detection must record its signals so users can audit.
+#[tokio::test]
+async fn test_detection_signals_populated_for_timing_only() {
+    let (host, port, handle) = start_slow_server().await;
+
+    let pb = ProgressBar::new_spinner();
+    pb.finish_and_clear();
+
+    let attack_requests = vec![format!(
+        "GET / HTTP/1.1\r\nHost: {}\r\nContent-Length: 5\r\n\r\ntest1",
+        host
+    )];
+
+    let result = run_checks_for_type(CheckParams {
+        pb: &pb,
+        check_name: "TE.CL",
+        host: &host,
+        port,
+        path: "/",
+        attack_requests,
+        timeout: 5,
+        verbose: false,
+        use_tls: false,
+        export_dir: None,
+        current_check: 1,
+        total_checks: 1,
+        delay: 0,
+        baseline_count: DEFAULT_BASELINE_COUNT,
+    })
+    .await;
+
+    handle.abort();
+    let check_result = result.unwrap();
+    assert!(check_result.vulnerable);
+    assert!(
+        !check_result.detection_signals.is_empty(),
+        "Detection signals must be populated for any vulnerability"
+    );
+    assert!(
+        check_result
+            .detection_signals
+            .iter()
+            .any(|s| s.starts_with("timing_anomaly")),
+        "Timing-only detection must record timing_anomaly signal, got: {:?}",
+        check_result.detection_signals
     );
 }

--- a/tests/scanner_tests.rs
+++ b/tests/scanner_tests.rs
@@ -337,6 +337,7 @@ fn test_check_result_vulnerable_state() {
         payload: None,
         confidence: None,
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     };
 
     assert!(result.vulnerable);
@@ -359,6 +360,7 @@ fn test_check_result_not_vulnerable_state() {
         payload: None,
         confidence: None,
         detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
     };
 
     assert!(!result.vulnerable);
@@ -1837,6 +1839,107 @@ async fn test_method_matched_baseline_suppresses_post_only_slowness() {
     assert!(
         !check_result.vulnerable,
         "POST-intrinsic slowness must be absorbed by method-matched baseline, not flagged"
+    );
+}
+
+/// Consecutive FP-rejection early-termination: a backend where every
+/// TE-carrying request slows uniformly (control comparison rejects each
+/// one) must short-circuit the check after N consecutive control-FP
+/// rejections. The check result records the reason in `diagnostics` and
+/// the scan does not iterate through every payload variation.
+#[tokio::test]
+async fn test_consecutive_fp_rejections_short_circuit_check() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let host = addr.ip().to_string();
+    let port = addr.port();
+
+    let handle = tokio::spawn(async move {
+        loop {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 8192];
+                    let n_read = socket.read(&mut buf).await.unwrap_or(0);
+                    let req = String::from_utf8_lossy(&buf[..n_read]).to_ascii_lowercase();
+
+                    // Slow on any request that carries a body (TE or non-zero
+                    // CL). CL:0 baselines and bare GETs are fast. Each TE
+                    // payload variant therefore detects + is rejected via
+                    // control timing similarity.
+                    let has_body = req.contains("transfer-encoding")
+                        || req.lines().any(|l| {
+                            let lt = l.trim_start();
+                            lt.starts_with("content-length:")
+                                && !lt
+                                    .trim_start_matches("content-length:")
+                                    .trim()
+                                    .starts_with('0')
+                        });
+                    if has_body {
+                        tokio::time::sleep(Duration::from_millis(1500)).await;
+                    }
+                    let response = "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nHello, World!";
+                    let _ = socket.write_all(response.as_bytes()).await;
+                });
+            }
+        }
+    });
+
+    let pb = ProgressBar::new_spinner();
+    pb.finish_and_clear();
+
+    // Provide many payload variants so iteration would be very expensive
+    // without early termination. Each is a CL.TE-shaped TE payload.
+    let attack_requests: Vec<String> = (0..20)
+        .map(|i| {
+            format!(
+                "POST /p{} HTTP/1.1\r\nHost: {}\r\nTransfer-Encoding: chunked\r\nContent-Length: 6\r\n\r\n0\r\n\r\nG",
+                i, host
+            )
+        })
+        .collect();
+
+    let start = std::time::Instant::now();
+    let result = run_checks_for_type(CheckParams {
+        pb: &pb,
+        check_name: "CL.TE",
+        host: &host,
+        port,
+        path: "/",
+        attack_requests,
+        timeout: 6,
+        verbose: false,
+        use_tls: false,
+        export_dir: None,
+        current_check: 1,
+        total_checks: 1,
+        delay: 0,
+        baseline_count: DEFAULT_BASELINE_COUNT,
+    })
+    .await;
+    let elapsed = start.elapsed();
+
+    handle.abort();
+    let check_result = result.unwrap();
+    assert!(
+        !check_result.vulnerable,
+        "Uniform slow-on-body backend must be rejected as FP"
+    );
+    assert!(
+        check_result
+            .diagnostics
+            .iter()
+            .any(|d| d.starts_with("early_termination:consecutive_fp_rejections")),
+        "Expected early_termination diagnostic, got: {:?}",
+        check_result.diagnostics
+    );
+    // Sanity: the entire 20-payload sweep would take ~5 min without early
+    // termination. Capping at 60s gives margin while catching regressions
+    // where the limit stops being honored.
+    assert!(
+        elapsed.as_secs() < 60,
+        "early termination should keep the check well under 60s, got {:?}",
+        elapsed
     );
 }
 


### PR DESCRIPTION
## Summary

Replaces the single-signal timing-based smuggling detection with a layered pipeline of orthogonal signals — and adds a local validation lab — to reduce the false positives request-smuggling detection is prone to.

**Detection pipeline**

- Robust baseline: median + max + noise-aware threshold (`max + buffer`), majority-based timeout suppression, method-matched POST baseline that lifts the floor on backends where POSTs are intrinsically slower than GETs
- 3-retry confirmation: strict majority for timing/status, **all** retries for connection timeouts and status-only (408/504 without timing anomaly) — the noisiest signals
- Differential control: smuggling-stripped sibling payload with body-size matching, 2 samples aggregated by MAX, rejects findings where control timing/status mirror the attack
- Body and header divergence escape clauses — structural body-size diff (>25%) or response-header set diff (≥2 fields) override timing-similarity rejection when smuggling artifacts changed how the backend interpreted the request
- Post-attack follow-up GETs: fresh probes against baseline; any divergence overrides FP rejection (the canonical second-request smuggling signature)
- Consecutive FP-rejection early termination — if the same check rejects N payloads in a row via control, abandon the rest and record an `early_termination:consecutive_fp_rejections=N` diagnostic
- Variance-aware confidence demotion: timing-only detections on high-variance baselines are demoted to Low

**Transparency**

`CheckResult` now exposes `detection_signals: Vec<String>` (e.g. `timing_anomaly:3.5x`, `status_504`, `body_divergence_vs_control`, `header_divergence_vs_control:N`, `followup_divergence:N/total`, `extreme_timing`, `baseline_noisy`, `connection_timeout`) and `diagnostics: Vec<String>` in JSON output, so users can audit why a finding was reported and corroborate manually.

**Validation harness** (`lab/`)

End-to-end harness invoking the actual binary against 12 socket-level mock backends covering canonical FP and TP scenarios:

| Type | Scenario | Verifies |
|---|---|---|
| FP | `FP_clean` | baseline sanity |
| FP | `FP_slow_post_uniform` | method-matched POST baseline |
| FP | `FP_uniform_504` | majority-timeout suppression |
| FP | `FP_noisy_baseline` | max+buffer noise floor |
| FP | `FP_heavy_post` | control rejection + R10 early termination |
| FP | `FP_waf_blocks_te` | WAF status/body diffs not over-interpreted |
| FP | `FP_natural_body_jitter` | divergence heuristics tolerate ±4% body variation |
| FP | `FP_intermittent_504` | strict-majority + all-retries-for-status-only handle ~5% flake rates |
| TP | `TP_clte_status` | `status_504` signal |
| TP | `TP_clte_timing` | `timing_anomaly` signal |
| TP | `TP_followup_desync` | `followup_divergence` is the *only* escape keeping the finding alive |
| TP | `TP_body_divergence` | `body_divergence_vs_control` overrides timing similarity |

Each TP scenario asserts the *specific* signal pathway exercised so escape clauses are validated in isolation. Run with `just lab`.

**Known limitations** (documented in `lab/README.md`):

- Pathologically high intermittent failure rates (≥20%) can still false-confirm with low probability — the exit-first design does not sample across multiple payload variants statistically.

## Test plan

- [x] `cargo test` — 412 unit/integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `just lab` — 12/12 scenarios pass against the release binary
- [ ] Manual smoke against a real PortSwigger Web Security Academy lab (suggested follow-up)