### PR TITLE
feat: improve AI/agent/scripting friendliness (clean JSON, exit codes, batch output)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,24 @@ Key dependencies and their purposes:
 pub option_name: Option<String>,
 ```
 
+### Machine-Readable / AI-Friendly Output
+- Use `OutputFormat` (already supports `Json` via `-f json` / `--json`).
+- When emitting JSON, **never write anything except the JSON document to stdout**.
+  - Use the existing `is_machine()` / `set_machine(true)` helpers (or `cli.effective_format().is_json()`).
+  - All human logs must go to stderr or be suppressed.
+- **Exit codes are part of the contract**:
+  - `0` = no vulnerabilities found across all targets
+  - `1` = at least one vulnerability found (use for agent branching / CI)
+  - `2` = usage or input error
+- For batch scans (multiple URLs or stdin), collect results first and emit a single top-level JSON document (either a bare array or an envelope with `results` + `summary`).
+- The `ScanResults` / `CheckResult` models already contain rich `detection_signals`, `confidence`, `diagnostics`, and raw `payload` — ideal for LLMs to reason about findings.
+
+Example CLI addition for shorthand:
+```rust
+#[arg(long = "json", action = clap::ArgAction::SetTrue)]
+pub json: bool,
+```
+
 ### Creating Attack Payloads
 ```rust
 pub fn get_attack_payloads(

--- a/README.md
+++ b/README.md
@@ -65,6 +65,29 @@ smugglex https://target.com -v -o results.json
 cat urls.txt | smugglex --exit-first
 ```
 
+## For AI Agents, Scripts & CI
+
+smugglex is designed to be friendly to automated usage:
+
+```bash
+# Clean JSON output (only JSON on stdout) + proper exit code
+smugglex --json https://target.com
+echo $?   # 0 = clean, 1 = vulnerable found
+
+# Batch + structured output (single valid JSON document)
+cat urls.txt | smugglex -f json -o report.json
+
+# Quiet + JSON for pipelines
+smugglex -q --json https://target.com | jq '.summary.vulnerable_targets'
+```
+
+Exit codes:
+- `0` — No vulnerabilities found
+- `1` — At least one vulnerability found
+- `2` — Usage / input error
+
+See the [Pipeline Guide](https://smugglex.hahwul.com/advanced/pipeline/) and [Output Formats](https://smugglex.hahwul.com/usage/output/) for more.
+
 ## Troubleshooting
 
 Common issues and solutions are available in the [Troubleshooting Guide](https://smugglex.hahwul.com/support/troubleshooting/).

--- a/docs/content/advanced/pipeline.md
+++ b/docs/content/advanced/pipeline.md
@@ -41,11 +41,18 @@ cat urls.txt | smugglex -x http://127.0.0.1:8080
 
 ## CI/CD Integration
 
-Use quiet mode and JSON output for automated security checks:
+Use JSON + exit codes for reliable automation. The tool exits with:
+- `0` — no vulnerabilities
+- `1` — vulnerabilities found
+- `2` — input/usage error
 
 ```bash
-smugglex -q -f json -o report.json https://staging.example.com
-# Process report.json in your pipeline
+# Recommended for agents/CI
+smugglex -q --json -o report.json https://staging.example.com
+echo $?   # inspect exit code
+
+# Or pipe directly
+cat urls.txt | smugglex --json | jq '.summary.vulnerable_targets'
 ```
 
 ## Fast Scan for Large Target Lists

--- a/docs/content/usage/output.md
+++ b/docs/content/usage/output.md
@@ -18,36 +18,43 @@ smugglex https://target.com
 [OK] TE.TE - https://target.com
 ```
 
-## JSON
+## JSON (Machine Readable)
 
-Structured output for integration with other tools.
+Use `-f json` or `--json` for clean, structured output suitable for AI agents, scripts, jq, and CI systems.
 
 ```bash
-smugglex -f json -o results.json https://target.com
+smugglex --json https://target.com
+# or the equivalent:
+smugglex -f json https://target.com
 ```
+
+Key properties for automation:
+- **Stdout is pure JSON** — no progress bars, no log lines.
+- **Exit code** indicates findings: `0` = clean, `1` = vulnerable found.
+- Single target → `ScanResults` object (per-target schema).
+- Multiple targets / stdin batch → envelope with `results[]` + `summary`:
 
 ```json
 {
-  "target": "https://target.com",
-  "method": "POST",
-  "timestamp": "2025-01-15T10:30:00Z",
-  "fingerprint": {
-    "detected_proxy": "nginx",
-    "server": "nginx/1.24.0"
-  },
-  "checks": [
-    {
-      "check_type": "cl-te",
-      "vulnerable": true,
-      "payload_index": 3,
-      "normal_status": 200,
-      "attack_status": 200,
-      "normal_duration_ms": 45,
-      "attack_duration_ms": 5023,
-      "confidence": "high"
-    }
-  ]
+  "smugglex_version": "0.2.0",
+  "timestamp": "...",
+  "results": [
+    { "target": "...", "checks": [...], "error": null },
+    ...
+  ],
+  "summary": {
+    "total_targets": 12,
+    "vulnerable_targets": 3,
+    "total_checks": 84,
+    "vulnerable_checks": 5
+  }
 }
+```
+
+Write to file while keeping stdout clean:
+
+```bash
+smugglex --json -o report.json https://target.com
 ```
 
 ## Export Payloads

--- a/docs/content/usage/output.md
+++ b/docs/content/usage/output.md
@@ -30,16 +30,16 @@ smugglex -f json https://target.com
 
 Key properties for automation:
 - **Stdout is pure JSON** — no progress bars, no log lines.
-- **Exit code** indicates findings: `0` = clean, `1` = vulnerable found.
-- Single target → `ScanResults` object (per-target schema).
-- Multiple targets / stdin batch → envelope with `results[]` + `summary`:
+- **Exit code** indicates findings: `0` = clean, `1` = vulnerable found, `2` = input/usage error.
+- JSON mode always emits a batch envelope with `results[]` + `summary`, even for a single target.
 
 ```json
 {
   "smugglex_version": "0.2.0",
   "timestamp": "...",
   "results": [
-    { "target": "...", "checks": [...], "error": null },
+    { "target": "...", "checks": [...] },
+    { "target": "...", "checks": [], "error": "URL parse error: ..." },
     ...
   ],
   "summary": {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,6 +73,10 @@ pub struct Cli {
     #[arg(help_heading = "OUTPUT", short = 'f', long = "format", default_value_t = OutputFormat::Plain)]
     pub format: OutputFormat,
 
+    /// Shorthand for --format json (machine-readable output for scripts and AI agents)
+    #[arg(help_heading = "OUTPUT", long = "json", action = clap::ArgAction::SetTrue)]
+    pub json: bool,
+
     /// Export payloads to directory when vulnerabilities are found
     #[arg(help_heading = "OUTPUT", long = "export-payloads")]
     pub export_dir: Option<String>,
@@ -171,6 +175,16 @@ impl Cli {
         }
         if let Some(ref proxy) = self.proxy {
             crate::http::set_proxy(proxy.clone());
+        }
+    }
+
+    /// Returns the effective output format, honoring both --format and the --json shorthand.
+    /// --json takes precedence for convenience in scripting/AI usage.
+    pub fn effective_format(&self) -> OutputFormat {
+        if self.json {
+            OutputFormat::Json
+        } else {
+            self.format.clone()
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,15 +13,18 @@ use smugglex::exploit::{
     test_path_fuzz,
 };
 use smugglex::fingerprint::{fingerprint_target, suggest_checks};
-use smugglex::model::{CheckResult, FingerprintInfo};
+use smugglex::model::{CheckResult, FingerprintInfo, ScanResults};
 use smugglex::mutator::{Mutator, MutatorConfig};
-use smugglex::output::{log_scan_results, save_results_to_file};
+use smugglex::output::{
+    build_batch_results, log_scan_results, print_batch_json, save_batch_to_file,
+    save_results_to_file,
+};
 use smugglex::payloads::{
     get_cl_edge_case_payloads, get_cl_te_payloads, get_h2_payloads, get_h2c_payloads,
     get_te_cl_payloads, get_te_te_payloads,
 };
 use smugglex::scanner::{CheckParams, run_checks_for_type};
-use smugglex::utils::{LogLevel, fetch_cookies, log};
+use smugglex::utils::{LogLevel, fetch_cookies, is_machine, log, set_machine};
 
 #[derive(Debug)]
 struct ExploitParams<'a> {
@@ -39,10 +42,54 @@ struct ExploitParams<'a> {
     delay: u64,
 }
 
+/// Outcome of scanning a single target. Used to collect results for batch JSON output
+/// and to determine the final exit code (0 = clean, 1 = vulnerable found).
+#[derive(Debug)]
+#[allow(dead_code)]
+enum ScanOutcome {
+    Success {
+        target: String,
+        scan_results: ScanResults,
+        found_vulnerability: bool,
+    },
+    Failure {
+        target: String,
+        error: String,
+    },
+}
+
+#[allow(dead_code)]
+impl ScanOutcome {
+    fn target(&self) -> &str {
+        match self {
+            ScanOutcome::Success { target, .. } => target,
+            ScanOutcome::Failure { target, .. } => target,
+        }
+    }
+
+    fn is_vulnerable(&self) -> bool {
+        matches!(
+            self,
+            ScanOutcome::Success {
+                found_vulnerability: true,
+                ..
+            }
+        )
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
     cli.apply_global_settings();
+
+    // Activate machine mode for clean structured output (used by AI agents, scripts, CI).
+    // When active, stdout will contain *only* JSON; all chatter goes to stderr or is suppressed.
+    if cli.effective_format().is_json() {
+        set_machine(true);
+        // In pure machine mode we also want to suppress most progress noise.
+        // (progress bar creation below already respects verbose, we additionally hide it for json)
+    }
 
     if cli.version {
         println!("smugglex {}", env!("CARGO_PKG_VERSION"));
@@ -51,36 +98,102 @@ async fn main() -> Result<()> {
 
     let urls = resolve_urls(&cli)?;
     if urls.is_empty() {
-        eprintln!("{} No valid URLs provided", "[!]".yellow().bold());
-        return Ok(());
+        if cli.effective_format().is_json() {
+            // Produce a valid (empty) JSON envelope even on input error so AI agents can parse uniformly.
+            let empty_batch = build_batch_results(Vec::new(), Some(env!("CARGO_PKG_VERSION")));
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&empty_batch).unwrap_or_default()
+            );
+        } else {
+            eprintln!("{} No valid URLs provided", "[!]".yellow().bold());
+        }
+        // Usage/input error → exit 2 (common convention for CLI tools)
+        std::process::exit(2);
     }
 
+    // Collect outcomes from all targets. This enables:
+    // - Clean single JSON document for batch scans (critical for AI / jq / scripts)
+    // - Correct exit code (0 = clean, 1 = vulnerable found)
+    let mut outcomes: Vec<ScanOutcome> = Vec::with_capacity(urls.len());
+
     if cli.concurrency > 1 {
-        // Process URLs concurrently in chunks
+        // Concurrent processing in chunks (preserves previous backpressure behavior)
         for chunk in urls.chunks(cli.concurrency) {
             let mut handles = Vec::new();
             for target_url in chunk {
                 let url = target_url.clone();
                 let cli_ref = cli.clone();
-                handles.push(tokio::spawn(async move {
-                    if let Err(e) = process_url(&url, &cli_ref).await {
-                        log(LogLevel::Error, &format!("error processing {}: {}", url, e));
-                    }
-                }));
+                handles.push(tokio::spawn(
+                    async move { scan_one_target(url, cli_ref).await },
+                ));
             }
             for handle in handles {
-                let _ = handle.await;
+                match handle.await {
+                    Ok(outcome) => outcomes.push(outcome),
+                    Err(join_err) => {
+                        // Join error (task panicked) — surface to stderr
+                        log(
+                            LogLevel::Error,
+                            &format!("worker task failed: {}", join_err),
+                        );
+                    }
+                }
             }
         }
     } else {
         for target_url in urls {
-            if let Err(e) = process_url(&target_url, &cli).await {
-                log(
-                    LogLevel::Error,
-                    &format!("error processing {}: {}", target_url, e),
-                );
-            }
+            let outcome = scan_one_target(target_url, cli.clone()).await;
+            outcomes.push(outcome);
         }
+    }
+
+    // Compute overall vulnerability status for exit code
+    let any_vulnerable = outcomes.iter().any(|o| o.is_vulnerable());
+
+    // Emit results
+    let json_mode = cli.effective_format().is_json();
+    if json_mode {
+        // Convert outcomes to ScanResults (synthesize minimal entry for failures so every
+        // requested target appears in the output).
+        let scan_results: Vec<ScanResults> = outcomes
+            .into_iter()
+            .map(|o| match o {
+                ScanOutcome::Success { scan_results, .. } => scan_results,
+                ScanOutcome::Failure { target, error } => ScanResults {
+                    target,
+                    method: cli.method.clone(),
+                    timestamp: chrono::Utc::now().to_rfc3339(),
+                    fingerprint: None,
+                    checks: Vec::new(),
+                    error: Some(error),
+                },
+            })
+            .collect();
+
+        let batch = build_batch_results(scan_results, Some(env!("CARGO_PKG_VERSION")));
+        print_batch_json(&batch);
+
+        if let Some(ref output_file) = cli.output
+            && let Err(e) = save_batch_to_file(&batch, output_file)
+        {
+            log(
+                LogLevel::Error,
+                &format!("failed to write batch output file: {}", e),
+            );
+        }
+    } else {
+        // Plain text mode: preserve previous per-target human output behavior.
+        // We already printed inside scan_one_target for the non-json path.
+        // (scan_one_target calls log_scan_results when not in machine mode.)
+        // Nothing more to do here for output.
+    }
+
+    // Final timing is intentionally omitted in machine mode to keep stdout pure.
+    // In plain mode the per-target "scan completed in" messages were already emitted by the old path.
+
+    if any_vulnerable {
+        std::process::exit(1);
     }
 
     Ok(())
@@ -108,48 +221,92 @@ fn resolve_urls(cli: &Cli) -> Result<Vec<String>> {
     }
 }
 
-async fn process_url(target_url: &str, cli: &Cli) -> Result<()> {
+/// Core scan routine for one target. Returns a ScanOutcome (Success with full ScanResults
+/// or Failure with error string).
+///
+/// In non-machine (plain text) mode it performs the same human-readable logging as before.
+/// In machine/JSON mode it suppresses all human chatter and progress output so that the
+/// only thing on stdout is the final structured JSON (emitted by the caller).
+async fn scan_one_target(target: String, cli: Cli) -> ScanOutcome {
     let start_time = std::time::Instant::now();
+    let target_url = target.as_str();
 
-    let url = Url::parse(target_url)?;
-    let host = url.host_str().ok_or("Invalid host")?;
-    let port = url.port_or_known_default().ok_or("Invalid port")?;
+    let url = match Url::parse(target_url) {
+        Ok(u) => u,
+        Err(e) => {
+            return ScanOutcome::Failure {
+                target: target_url.to_string(),
+                error: format!("URL parse error: {}", e),
+            };
+        }
+    };
+
+    let host = match url.host_str() {
+        Some(h) => h,
+        None => {
+            return ScanOutcome::Failure {
+                target: target_url.to_string(),
+                error: "Invalid host in URL".to_string(),
+            };
+        }
+    };
+    let port = match url.port_or_known_default() {
+        Some(p) => p,
+        None => {
+            return ScanOutcome::Failure {
+                target: target_url.to_string(),
+                error: "Invalid port in URL".to_string(),
+            };
+        }
+    };
     let path = url.path();
     let use_tls = url.scheme() == "https";
     let host_header = cli.vhost.as_deref().unwrap_or(host);
 
-    log(LogLevel::Info, &format!("start scan to {}", target_url));
-
-    let cookies = if cli.use_cookies {
-        fetch_cookies(host, port, path, use_tls, cli.timeout, cli.verbose).await?
-    } else {
-        Vec::new()
-    };
-    if !cookies.is_empty() {
-        log(
-            LogLevel::Info,
-            &format!("found {} cookie(s)", cookies.len()),
-        );
+    // Human logs only in plain mode
+    if !is_machine() {
+        log(LogLevel::Info, &format!("start scan to {}", target_url));
     }
 
-    let pb = setup_progress_bar(cli.verbose);
+    let cookies = match fetch_cookies(host, port, path, use_tls, cli.timeout, cli.verbose).await {
+        Ok(c) => {
+            if !c.is_empty() && !is_machine() {
+                log(LogLevel::Info, &format!("found {} cookie(s)", c.len()));
+            }
+            c
+        }
+        Err(e) => {
+            // Cookie fetch failure is non-fatal for the scan itself
+            if !is_machine() {
+                log(LogLevel::Warning, &format!("cookie fetch failed: {}", e));
+            }
+            Vec::new()
+        }
+    };
+
+    // Progress bar is hidden in machine mode or when verbose (old behavior)
+    let pb = setup_progress_bar(cli.verbose || is_machine());
 
     // Fingerprinting pre-step
     let mut fingerprint_info: Option<FingerprintInfo> = None;
     let mut suggested_order: Option<Vec<&str>> = None;
 
     if cli.fingerprint {
-        log(LogLevel::Info, "running proxy fingerprint probe");
+        if !is_machine() {
+            log(LogLevel::Info, "running proxy fingerprint probe");
+        }
         match fingerprint_target(host, port, path, cli.timeout, cli.verbose, use_tls).await {
             Ok(fp) => {
-                log(
-                    LogLevel::Info,
-                    &format!("detected proxy: {}", fp.detected_proxy),
-                );
-                if let Some(ref server) = fp.server_header {
-                    log(LogLevel::Info, &format!("server header: {}", server));
+                if !is_machine() {
+                    log(
+                        LogLevel::Info,
+                        &format!("detected proxy: {}", fp.detected_proxy),
+                    );
+                    if let Some(ref server) = fp.server_header {
+                        log(LogLevel::Info, &format!("server header: {}", server));
+                    }
                 }
-                if cli.format.is_json() {
+                if cli.effective_format().is_json() {
                     fingerprint_info = Some(FingerprintInfo {
                         detected_proxy: fp.detected_proxy.to_string(),
                         server_header: fp.server_header.clone(),
@@ -160,10 +317,12 @@ async fn process_url(target_url: &str, cli: &Cli) -> Result<()> {
                 suggested_order = Some(suggest_checks(&fp));
             }
             Err(e) => {
-                log(
-                    LogLevel::Warning,
-                    &format!("fingerprint probe failed: {}", e),
-                );
+                if !is_machine() {
+                    log(
+                        LogLevel::Warning,
+                        &format!("fingerprint probe failed: {}", e),
+                    );
+                }
             }
         }
     }
@@ -187,7 +346,6 @@ async fn process_url(target_url: &str, cli: &Cli) -> Result<()> {
             .filter(|(name, _)| selected_checks.contains(name))
             .collect()
     } else if let Some(ref order) = suggested_order {
-        // Reorder checks based on fingerprint suggestion
         let mut ordered = Vec::new();
         for name in order {
             if let Some(entry) = all_checks.iter().find(|(n, _)| n == name) {
@@ -240,27 +398,44 @@ async fn process_url(target_url: &str, cli: &Cli) -> Result<()> {
             baseline_count: cli.baseline_count,
         };
 
-        let result = run_checks_for_type(params).await?;
-        found_vulnerability |= result.vulnerable;
-        results.push(result);
-        pb.inc(1);
+        match run_checks_for_type(params).await {
+            Ok(result) => {
+                found_vulnerability |= result.vulnerable;
+                results.push(result);
+                pb.inc(1);
+            }
+            Err(e) => {
+                // Record as diagnostic but continue with other checks
+                if !is_machine() {
+                    log(
+                        LogLevel::Warning,
+                        &format!("{} check failed: {}", check_name, e),
+                    );
+                }
+            }
+        }
     }
 
-    if !cli.verbose {
+    if !cli.verbose && !is_machine() {
         pb.finish_and_clear();
     }
 
-    log_scan_results(
-        &results,
-        &cli.format,
-        target_url,
-        &cli.method,
-        &fingerprint_info,
-    );
+    // In machine mode we never call log_scan_results here — the caller will emit one clean JSON document.
+    if !is_machine() {
+        log_scan_results(
+            &results,
+            &cli.effective_format(),
+            target_url,
+            &cli.method,
+            &fingerprint_info,
+        );
+    }
 
-    // Run exploits if requested and vulnerabilities were found
+    // Run exploits only in plain mode (their output is human-oriented).
+    // In machine/JSON mode we still allow payload export via the check phase, but skip exploit execution
+    // to keep stdout clean and because exploit details are better consumed interactively.
     if let Some(ref exploit_str) = cli.exploit {
-        if found_vulnerability {
+        if found_vulnerability && !is_machine() {
             let exploit_params = ExploitParams {
                 exploit_str,
                 results: &results,
@@ -275,8 +450,15 @@ async fn process_url(target_url: &str, cli: &Cli) -> Result<()> {
                 wordlist_path: cli.exploit_wordlist.as_deref(),
                 delay: cli.delay,
             };
-            run_exploits(&exploit_params).await?;
-        } else {
+            if let Err(e) = run_exploits(&exploit_params).await {
+                log(LogLevel::Error, &format!("exploit phase failed: {}", e));
+            }
+        } else if found_vulnerability && is_machine() {
+            log(
+                LogLevel::Warning,
+                "exploit requested in JSON mode; skipping (re-run without --json/-f json for exploit output)",
+            );
+        } else if !is_machine() {
             log(
                 LogLevel::Warning,
                 "exploit requested but no vulnerabilities found to exploit",
@@ -284,23 +466,47 @@ async fn process_url(target_url: &str, cli: &Cli) -> Result<()> {
         }
     }
 
-    if let Some(ref output_file) = cli.output {
-        save_results_to_file(
+    // Per-target file output (-o) is only done for plain mode here.
+    // For JSON batch the caller writes the full envelope once at the end.
+    if !is_machine()
+        && let Some(ref output_file) = cli.output
+        && let Err(e) = save_results_to_file(
             output_file,
             target_url,
             &cli.method,
-            results,
+            results.clone(),
             &fingerprint_info,
-        )?;
+        )
+    {
+        log(
+            LogLevel::Error,
+            &format!("failed to write output file: {}", e),
+        );
     }
 
     let duration = start_time.elapsed();
-    log(
-        LogLevel::Info,
-        &format!("scan completed in {:.3} seconds", duration.as_secs_f64()),
-    );
+    if !is_machine() {
+        log(
+            LogLevel::Info,
+            &format!("scan completed in {:.3} seconds", duration.as_secs_f64()),
+        );
+    }
 
-    Ok(())
+    // Build the structured result for the outcome (always produced, used for JSON batch or exit code)
+    let scan_results = ScanResults {
+        target: target_url.to_string(),
+        method: cli.method.clone(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        fingerprint: fingerprint_info,
+        checks: results,
+        error: None,
+    };
+
+    ScanOutcome::Success {
+        target: target_url.to_string(),
+        scan_results,
+        found_vulnerability,
+    }
 }
 
 fn setup_progress_bar(verbose: bool) -> ProgressBar {

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,10 +101,27 @@ async fn main() -> Result<()> {
         if cli.effective_format().is_json() {
             // Produce a valid (empty) JSON envelope even on input error so AI agents can parse uniformly.
             let empty_batch = build_batch_results(Vec::new(), Some(env!("CARGO_PKG_VERSION")));
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&empty_batch).unwrap_or_default()
-            );
+            match serde_json::to_string_pretty(&empty_batch) {
+                Ok(json) => println!("{}", json),
+                Err(e) => {
+                    log(
+                        LogLevel::Error,
+                        &format!("failed to serialize empty batch results: {}", e),
+                    );
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "results": [],
+                            "summary": {
+                                "total_targets": 0,
+                                "vulnerable_targets": 0,
+                                "total_checks": 0,
+                                "vulnerable_checks": 0
+                            }
+                        })
+                    );
+                }
+            }
         } else {
             eprintln!("{} No valid URLs provided", "[!]".yellow().bold());
         }
@@ -124,19 +141,25 @@ async fn main() -> Result<()> {
             for target_url in chunk {
                 let url = target_url.clone();
                 let cli_ref = cli.clone();
-                handles.push(tokio::spawn(
-                    async move { scan_one_target(url, cli_ref).await },
+                handles.push((
+                    url.clone(),
+                    tokio::spawn(async move { scan_one_target(url, cli_ref).await }),
                 ));
             }
-            for handle in handles {
+            for (target, handle) in handles {
                 match handle.await {
                     Ok(outcome) => outcomes.push(outcome),
                     Err(join_err) => {
-                        // Join error (task panicked) — surface to stderr
-                        log(
-                            LogLevel::Error,
-                            &format!("worker task failed: {}", join_err),
-                        );
+                        if !is_machine() {
+                            log(
+                                LogLevel::Error,
+                                &format!("worker task failed for {}: {}", target, join_err),
+                            );
+                        }
+                        outcomes.push(ScanOutcome::Failure {
+                            target,
+                            error: format!("worker task failed: {}", join_err),
+                        });
                     }
                 }
             }
@@ -150,6 +173,9 @@ async fn main() -> Result<()> {
 
     // Compute overall vulnerability status for exit code
     let any_vulnerable = outcomes.iter().any(|o| o.is_vulnerable());
+    let any_failures = outcomes
+        .iter()
+        .any(|o| matches!(o, ScanOutcome::Failure { .. }));
 
     // Emit results
     let json_mode = cli.effective_format().is_json();
@@ -196,6 +222,10 @@ async fn main() -> Result<()> {
         std::process::exit(1);
     }
 
+    if any_failures {
+        std::process::exit(2);
+    }
+
     Ok(())
 }
 
@@ -230,34 +260,33 @@ fn resolve_urls(cli: &Cli) -> Result<Vec<String>> {
 async fn scan_one_target(target: String, cli: Cli) -> ScanOutcome {
     let start_time = std::time::Instant::now();
     let target_url = target.as_str();
+    let network_verbose = cli.verbose && !is_machine();
+
+    let scan_failure = |message: String| {
+        if !is_machine() {
+            log(
+                LogLevel::Error,
+                &format!("failed to scan {}: {}", target_url, message),
+            );
+        }
+        ScanOutcome::Failure {
+            target: target_url.to_string(),
+            error: message,
+        }
+    };
 
     let url = match Url::parse(target_url) {
         Ok(u) => u,
-        Err(e) => {
-            return ScanOutcome::Failure {
-                target: target_url.to_string(),
-                error: format!("URL parse error: {}", e),
-            };
-        }
+        Err(e) => return scan_failure(format!("URL parse error: {}", e)),
     };
 
     let host = match url.host_str() {
         Some(h) => h,
-        None => {
-            return ScanOutcome::Failure {
-                target: target_url.to_string(),
-                error: "Invalid host in URL".to_string(),
-            };
-        }
+        None => return scan_failure("Invalid host in URL".to_string()),
     };
     let port = match url.port_or_known_default() {
         Some(p) => p,
-        None => {
-            return ScanOutcome::Failure {
-                target: target_url.to_string(),
-                error: "Invalid port in URL".to_string(),
-            };
-        }
+        None => return scan_failure("Invalid port in URL".to_string()),
     };
     let path = url.path();
     let use_tls = url.scheme() == "https";
@@ -268,20 +297,24 @@ async fn scan_one_target(target: String, cli: Cli) -> ScanOutcome {
         log(LogLevel::Info, &format!("start scan to {}", target_url));
     }
 
-    let cookies = match fetch_cookies(host, port, path, use_tls, cli.timeout, cli.verbose).await {
-        Ok(c) => {
-            if !c.is_empty() && !is_machine() {
-                log(LogLevel::Info, &format!("found {} cookie(s)", c.len()));
+    let cookies = if cli.use_cookies {
+        match fetch_cookies(host, port, path, use_tls, cli.timeout, network_verbose).await {
+            Ok(c) => {
+                if !c.is_empty() && !is_machine() {
+                    log(LogLevel::Info, &format!("found {} cookie(s)", c.len()));
+                }
+                c
             }
-            c
-        }
-        Err(e) => {
-            // Cookie fetch failure is non-fatal for the scan itself
-            if !is_machine() {
-                log(LogLevel::Warning, &format!("cookie fetch failed: {}", e));
+            Err(e) => {
+                // Cookie fetch failure is non-fatal for the scan itself
+                if !is_machine() {
+                    log(LogLevel::Warning, &format!("cookie fetch failed: {}", e));
+                }
+                Vec::new()
             }
-            Vec::new()
         }
+    } else {
+        Vec::new()
     };
 
     // Progress bar is hidden in machine mode or when verbose (old behavior)
@@ -295,7 +328,7 @@ async fn scan_one_target(target: String, cli: Cli) -> ScanOutcome {
         if !is_machine() {
             log(LogLevel::Info, "running proxy fingerprint probe");
         }
-        match fingerprint_target(host, port, path, cli.timeout, cli.verbose, use_tls).await {
+        match fingerprint_target(host, port, path, cli.timeout, network_verbose, use_tls).await {
             Ok(fp) => {
                 if !is_machine() {
                     log(
@@ -389,7 +422,7 @@ async fn scan_one_target(target: String, cli: Cli) -> ScanOutcome {
             path,
             attack_requests: payloads,
             timeout: cli.timeout,
-            verbose: cli.verbose,
+            verbose: network_verbose,
             use_tls,
             export_dir: cli.export_dir.as_deref(),
             current_check: i + 1,
@@ -412,6 +445,21 @@ async fn scan_one_target(target: String, cli: Cli) -> ScanOutcome {
                         &format!("{} check failed: {}", check_name, e),
                     );
                 }
+                results.push(CheckResult {
+                    check_type: check_name.to_string(),
+                    vulnerable: false,
+                    payload_index: None,
+                    normal_status: "CHECK_FAILED".to_string(),
+                    attack_status: None,
+                    normal_duration_ms: 0,
+                    attack_duration_ms: None,
+                    timestamp: chrono::Utc::now().to_rfc3339(),
+                    payload: None,
+                    confidence: None,
+                    detection_signals: Vec::new(),
+                    diagnostics: vec![format!("check_failed: {}", e)],
+                });
+                pb.inc(1);
             }
         }
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -80,4 +80,37 @@ pub struct ScanResults {
     pub fingerprint: Option<FingerprintInfo>,
     /// Results of each individual smuggling check
     pub checks: Vec<CheckResult>,
+    /// Error message if the target scan failed (e.g. connection or parsing error).
+    /// When present, `checks` will usually be empty.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Summary statistics for a batch of scan results.
+/// Useful for AI agents and scripts to get a quick overview without iterating.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BatchSummary {
+    /// Total number of targets that were processed (including errors)
+    pub total_targets: usize,
+    /// Number of targets on which at least one vulnerability was confirmed
+    pub vulnerable_targets: usize,
+    /// Total number of individual check runs across all targets
+    pub total_checks: usize,
+    /// Total number of checks that reported vulnerable=true
+    pub vulnerable_checks: usize,
+}
+
+/// Envelope for machine-readable (JSON) output when scanning multiple targets,
+/// or when using --json. Provides both detailed per-target results and a summary.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BatchScanResults {
+    /// smugglex version that produced this output
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub smugglex_version: Option<String>,
+    /// ISO 8601 timestamp when the batch run completed
+    pub timestamp: String,
+    /// Per-target results (one entry per attempted target)
+    pub results: Vec<ScanResults>,
+    /// Aggregate statistics
+    pub summary: BatchSummary,
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::io::Write;
 
 use crate::error::Result;
-use crate::model::{CheckResult, FingerprintInfo, ScanResults};
+use crate::model::{BatchScanResults, BatchSummary, CheckResult, FingerprintInfo, ScanResults};
 use crate::utils::{LogLevel, log};
 
 /// Log scan results in the specified output format (plain text or JSON).
@@ -24,6 +24,7 @@ pub fn log_scan_results(
             timestamp: Utc::now().to_rfc3339(),
             fingerprint: fingerprint_info.clone(),
             checks: results.to_vec(),
+            error: None,
         };
         match serde_json::to_string_pretty(&scan_results) {
             Ok(json_output) => println!("{}", json_output),
@@ -115,6 +116,7 @@ pub fn save_results_to_file(
         timestamp: Utc::now().to_rfc3339(),
         fingerprint: fingerprint_info.clone(),
         checks: results,
+        error: None,
     };
     let json_output = serde_json::to_string_pretty(&scan_results)?;
     if fs::metadata(output_file).is_ok() {
@@ -126,5 +128,68 @@ pub fn save_results_to_file(
     let mut file = fs::File::create(output_file)?;
     file.write_all(json_output.as_bytes())?;
     log(LogLevel::Info, &format!("results saved to {}", output_file));
+    Ok(())
+}
+
+/// Build a BatchScanResults envelope + summary from collected per-target results.
+/// `version` is optional (e.g. env!("CARGO_PKG_VERSION")).
+pub fn build_batch_results(results: Vec<ScanResults>, version: Option<&str>) -> BatchScanResults {
+    let total_targets = results.len();
+    let vulnerable_targets = results
+        .iter()
+        .filter(|r| r.checks.iter().any(|c| c.vulnerable))
+        .count();
+
+    let total_checks = results.iter().map(|r| r.checks.len()).sum();
+    let vulnerable_checks = results
+        .iter()
+        .flat_map(|r| r.checks.iter())
+        .filter(|c| c.vulnerable)
+        .count();
+
+    let summary = BatchSummary {
+        total_targets,
+        vulnerable_targets,
+        total_checks,
+        vulnerable_checks,
+    };
+
+    BatchScanResults {
+        smugglex_version: version.map(|s| s.to_string()),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        results,
+        summary,
+    }
+}
+
+/// Serialize and print a BatchScanResults as pretty JSON to stdout.
+/// This should be the *only* thing written to stdout in machine/JSON mode for batch runs.
+pub fn print_batch_json(batch: &BatchScanResults) {
+    match serde_json::to_string_pretty(batch) {
+        Ok(json) => println!("{}", json),
+        Err(e) => {
+            log(
+                LogLevel::Error,
+                &format!("failed to serialize batch results: {}", e),
+            );
+        }
+    }
+}
+
+/// Write batch results to a file (used by -o when emitting JSON for multiple targets).
+pub fn save_batch_to_file(batch: &BatchScanResults, output_file: &str) -> crate::error::Result<()> {
+    let json_output = serde_json::to_string_pretty(batch)?;
+    if fs::metadata(output_file).is_ok() {
+        log(
+            LogLevel::Warning,
+            &format!("overwriting existing file: {}", output_file),
+        );
+    }
+    let mut file = fs::File::create(output_file)?;
+    file.write_all(json_output.as_bytes())?;
+    log(
+        LogLevel::Info,
+        &format!("batch results saved to {}", output_file),
+    );
     Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 static QUIET: AtomicBool = AtomicBool::new(false);
+static MACHINE: AtomicBool = AtomicBool::new(false);
 
 /// Enable or disable quiet mode globally
 pub fn set_quiet(enabled: bool) {
@@ -15,6 +16,17 @@ pub fn set_quiet(enabled: bool) {
 /// Check if quiet mode is enabled
 pub fn is_quiet() -> bool {
     QUIET.load(Ordering::Relaxed)
+}
+
+/// Enable or disable machine mode (JSON / structured output).
+/// In machine mode, human-readable logs are suppressed or redirected to stderr.
+pub fn set_machine(enabled: bool) {
+    MACHINE.store(enabled, Ordering::Relaxed);
+}
+
+/// Check if machine mode (structured/JSON output) is active.
+pub fn is_machine() -> bool {
+    MACHINE.load(Ordering::Relaxed)
 }
 
 /// Fetch cookies from the target server
@@ -121,13 +133,43 @@ impl LogLevel {
             LogLevel::Error => "ERR".red(),
         }
     }
+
+    /// Plain (non-colored) prefix, used in machine mode where we write to stderr.
+    fn prefix_plain(&self) -> &'static str {
+        match self {
+            LogLevel::Info => "INF",
+            LogLevel::Warning => "WRN",
+            LogLevel::Error => "ERR",
+        }
+    }
 }
 
-/// Print a log message with timestamp and level prefix
+/// Print a log message with timestamp and level prefix.
+/// In machine mode (JSON output), Info is suppressed and non-Info goes to stderr
+/// so that stdout remains clean for structured data.
 pub fn log(level: LogLevel, message: &str) {
+    if is_machine() && matches!(level, LogLevel::Info) {
+        return;
+    }
     if is_quiet() && matches!(level, LogLevel::Info) {
         return;
     }
+
     let time = Local::now().format("%I:%M%p").to_string().to_uppercase();
-    println!("{} {} {}", time.dimmed(), level.prefix(), message);
+
+    if is_machine() {
+        // Machine mode: send warnings/errors to stderr without ANSI colors
+        // to avoid polluting JSON consumers.
+        match level {
+            LogLevel::Info => {
+                // Should not reach here (early return above), but be defensive.
+                eprintln!("{} {}", time, message);
+            }
+            _ => {
+                eprintln!("{} {} {}", time, level.prefix_plain(), message);
+            }
+        }
+    } else {
+        println!("{} {} {}", time.dimmed(), level.prefix(), message);
+    }
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -241,6 +241,35 @@ fn test_format_invalid_value() {
     assert!(result.is_err(), "format should reject invalid values");
 }
 
+#[test]
+fn test_json_shorthand_flag_sets_effective_json_format() {
+    let cli = Cli::parse_from(["smugglex", "http://example.com", "--json"]);
+    assert!(cli.json, "--json should set the shorthand flag");
+    assert!(
+        matches!(cli.effective_format(), OutputFormat::Json),
+        "effective format should be json when --json is set"
+    );
+}
+
+#[test]
+fn test_json_shorthand_takes_precedence_over_plain_format() {
+    let cli = Cli::parse_from([
+        "smugglex",
+        "http://example.com",
+        "--format",
+        "plain",
+        "--json",
+    ]);
+    assert!(
+        matches!(cli.format, OutputFormat::Plain),
+        "the explicit format flag should still parse as plain"
+    );
+    assert!(
+        matches!(cli.effective_format(), OutputFormat::Json),
+        "--json should take precedence in effective_format"
+    );
+}
+
 // Test exit-first option
 #[test]
 fn test_exit_first_short_flag() {

--- a/tests/main_tests.rs
+++ b/tests/main_tests.rs
@@ -210,6 +210,7 @@ async fn test_output_file_json_structure() {
             detection_signals: Vec::new(),
             diagnostics: Vec::new(),
         }],
+        error: None,
     };
 
     let json_output = serde_json::to_string_pretty(&scan_results);
@@ -235,6 +236,7 @@ async fn test_output_file_creation() {
         timestamp: Utc::now().to_rfc3339(),
         fingerprint: None,
         checks: vec![],
+        error: None,
     };
 
     let json_output = serde_json::to_string_pretty(&scan_results).unwrap();

--- a/tests/model_tests.rs
+++ b/tests/model_tests.rs
@@ -293,6 +293,7 @@ fn test_scan_results_creation() {
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         fingerprint: None,
         checks: vec![check1, check2],
+        error: None,
     };
 
     assert_eq!(scan_results.target, "https://example.com");
@@ -325,6 +326,7 @@ fn test_scan_results_serialization() {
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         fingerprint: None,
         checks: vec![check],
+        error: None,
     };
 
     let json = serde_json::to_string_pretty(&scan_results).expect("Failed to serialize");
@@ -372,6 +374,7 @@ fn test_scan_results_empty_checks() {
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         fingerprint: None,
         checks: vec![],
+        error: None,
     };
 
     assert_eq!(scan_results.checks.len(), 0);
@@ -435,6 +438,7 @@ fn test_scan_results_multiple_checks() {
         timestamp: "2024-01-01T12:00:00Z".to_string(),
         fingerprint: None,
         checks: checks.clone(),
+        error: None,
     };
 
     assert_eq!(scan_results.checks.len(), 3);

--- a/tests/output_tests.rs
+++ b/tests/output_tests.rs
@@ -2,9 +2,26 @@
 //!
 //! This module tests result formatting and file saving logic.
 
-use smugglex::model::{CheckResult, FingerprintInfo, ScanResults};
-use smugglex::output::save_results_to_file;
+use smugglex::model::{BatchScanResults, CheckResult, FingerprintInfo, ScanResults};
+use smugglex::output::{build_batch_results, save_batch_to_file, save_results_to_file};
 use std::fs;
+
+fn sample_check_result(check_type: &str, vulnerable: bool) -> CheckResult {
+    CheckResult {
+        check_type: check_type.to_string(),
+        vulnerable,
+        payload_index: Some(0),
+        normal_status: "HTTP/1.1 200 OK".to_string(),
+        attack_status: vulnerable.then_some("HTTP/1.1 504 Gateway Timeout".to_string()),
+        normal_duration_ms: 100,
+        attack_duration_ms: vulnerable.then_some(5000),
+        timestamp: "2024-01-01T00:00:00Z".to_string(),
+        payload: Some("test payload".to_string()),
+        confidence: None,
+        detection_signals: Vec::new(),
+        diagnostics: Vec::new(),
+    }
+}
 
 #[test]
 fn test_save_results_to_file_creates_json() {
@@ -12,20 +29,7 @@ fn test_save_results_to_file_creates_json() {
     let output_file = temp_dir.join("smugglex_test_output.json");
     let output_path = output_file.to_str().unwrap();
 
-    let results = vec![CheckResult {
-        check_type: "cl-te".to_string(),
-        vulnerable: true,
-        payload_index: Some(0),
-        normal_status: "HTTP/1.1 200 OK".to_string(),
-        attack_status: Some("HTTP/1.1 504 Gateway Timeout".to_string()),
-        normal_duration_ms: 100,
-        attack_duration_ms: Some(5000),
-        timestamp: "2024-01-01T00:00:00Z".to_string(),
-        payload: Some("test payload".to_string()),
-        confidence: None,
-        detection_signals: Vec::new(),
-        diagnostics: Vec::new(),
-    }];
+    let results = vec![sample_check_result("cl-te", true)];
 
     let result = save_results_to_file(output_path, "http://example.com", "GET", results, &None);
     assert!(result.is_ok());
@@ -55,20 +59,11 @@ fn test_save_results_to_file_with_fingerprint() {
         powered_by: None,
     });
 
-    let results = vec![CheckResult {
-        check_type: "te-cl".to_string(),
-        vulnerable: false,
-        payload_index: None,
-        normal_status: "HTTP/1.1 200 OK".to_string(),
-        attack_status: None,
-        normal_duration_ms: 50,
-        attack_duration_ms: None,
-        timestamp: "2024-01-01T00:00:00Z".to_string(),
-        payload: None,
-        confidence: None,
-        detection_signals: Vec::new(),
-        diagnostics: Vec::new(),
-    }];
+    let mut result = sample_check_result("te-cl", false);
+    result.payload_index = None;
+    result.payload = None;
+    result.normal_duration_ms = 50;
+    let results = vec![result];
 
     let result = save_results_to_file(
         output_path,
@@ -117,4 +112,66 @@ fn test_save_results_to_file_invalid_path() {
         &None,
     );
     assert!(result.is_err());
+}
+
+#[test]
+fn test_build_batch_results_summary_counts_failures_and_vulnerabilities() {
+    let results = vec![
+        ScanResults {
+            target: "http://one.example".to_string(),
+            method: "GET".to_string(),
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+            fingerprint: None,
+            checks: vec![
+                sample_check_result("cl-te", true),
+                sample_check_result("te-cl", false),
+            ],
+            error: None,
+        },
+        ScanResults {
+            target: "http://two.example".to_string(),
+            method: "GET".to_string(),
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+            fingerprint: None,
+            checks: vec![],
+            error: Some("URL parse error".to_string()),
+        },
+    ];
+
+    let batch = build_batch_results(results, Some("0.2.0"));
+
+    assert_eq!(batch.summary.total_targets, 2);
+    assert_eq!(batch.summary.vulnerable_targets, 1);
+    assert_eq!(batch.summary.total_checks, 2);
+    assert_eq!(batch.summary.vulnerable_checks, 1);
+}
+
+#[test]
+fn test_save_batch_to_file_creates_parseable_json() {
+    let temp_dir = std::env::temp_dir();
+    let output_file = temp_dir.join("smugglex_test_batch_output.json");
+    let output_path = output_file.to_str().unwrap();
+
+    let batch = build_batch_results(
+        vec![ScanResults {
+            target: "http://example.com".to_string(),
+            method: "GET".to_string(),
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+            fingerprint: None,
+            checks: vec![sample_check_result("cl-te", false)],
+            error: None,
+        }],
+        Some("0.2.0"),
+    );
+
+    let result = save_batch_to_file(&batch, output_path);
+    assert!(result.is_ok());
+
+    let content = fs::read_to_string(output_path).unwrap();
+    let parsed: BatchScanResults = serde_json::from_str(&content).unwrap();
+    assert_eq!(parsed.summary.total_targets, 1);
+    assert_eq!(parsed.results.len(), 1);
+    assert_eq!(parsed.results[0].target, "http://example.com");
+
+    fs::remove_file(output_path).ok();
 }


### PR DESCRIPTION
Major improvements to make smugglex excellent for AI agents, security automation, and CI/CD pipelines:

- Add `--json` shorthand flag (equivalent to `-f json`)
- When using JSON output (`-f json` / `--json`):
  - stdout now contains *only* valid JSON (no progress bars, logs, or human chatter)
  - All status messages suppressed or routed to stderr via machine mode
- Proper exit codes (critical for agents & CI):
  - 0 = no vulnerabilities found across all targets
  - 1 = at least one vulnerability found
  - 2 = usage/input error
- Batch / multi-target / stdin scans now produce a single parseable JSON document:
  - Envelope with `results[]` + rich `summary` (total_targets, vulnerable_targets, etc.)
  - Failed targets are included with an `error` field instead of breaking output
- Per-target file writes (`-o`) for JSON batch now correctly write the full envelope at the end
- Introduced `is_machine()` / `set_machine()` helpers + machine-aware logging
- Refactored main scan loop for clean result collection (`ScanOutcome`)
- Rich existing models (`CheckResult.detection_signals`, `confidence`, raw `payload`, `diagnostics`) are already ideal for LLM reasoning
- Updated README, usage/output docs, pipeline guide, and AGENTS.md

This makes smugglex trivial to integrate into agentic workflows:
  smugglex --json https://target.com | jq '.summary.vulnerable_targets'
  if smugglex --json "$url"; then ... fi

🤖 AI / scripting UX is now first-class.