### PR TITLE
feat(cli): support --raw-request to replay a captured request as template (#78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ Read URLs from stdin:
 cat urls.txt | smugglex
 ```
 
+Replay a captured request (e.g. exported from Burp Suite) as the request template:
+
+```bash
+smugglex --raw-request request.txt              # target taken from the Host header
+smugglex --raw-request request.txt --raw-request-proto http
+```
+
 For detailed usage and options, see [Usage Guide](https://smugglex.hahwul.com/usage/).
 
 ## Examples

--- a/docs/content/usage/options.md
+++ b/docs/content/usage/options.md
@@ -18,6 +18,8 @@ description = "All CLI options for smugglex"
 | `-t, --timeout` | 10 | Socket timeout in seconds |
 | `-H, --header` | | Custom header (repeatable) |
 | `--vhost` | | Virtual host for Host header |
+| `--raw-request` | | Read a raw HTTP request from a file and use it as the request template |
+| `--raw-request-proto` | https | Scheme for `--raw-request` when the request line is origin-form (`http` or `https`) |
 | `--cookies` | | Fetch and include cookies |
 | `-d, --delay` | 0 | Delay between requests in milliseconds |
 | `-j, --concurrency` | 1 | Number of URLs to scan concurrently |
@@ -66,6 +68,16 @@ smugglex --fingerprint --fuzz https://target.com
 
 # Custom headers and timeout
 smugglex -H "Authorization: Bearer token" -t 15 https://target.com
+
+# Replay a captured request (e.g. exported from Burp Suite) as the template.
+# Method, request-target, Host and headers (cookies, auth, ...) are reused;
+# the target is taken from the Host header. The body is replaced by the
+# generated smuggling payloads, and Content-Length / Transfer-Encoding are
+# managed by smugglex.
+smugglex --raw-request request.txt
+
+# Same, but the captured request targets a plain-HTTP service
+smugglex --raw-request request.txt --raw-request-proto http
 
 # Route through a proxy (e.g., Burp Suite)
 smugglex -x http://127.0.0.1:8080 https://target.com

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,7 +70,8 @@ pub struct Cli {
         help_heading = "REQUEST",
         long = "raw-request-proto",
         value_name = "SCHEME",
-        default_value = "https"
+        default_value = "https",
+        requires = "raw_request"
     )]
     pub raw_request_proto: String,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,19 @@ pub struct Cli {
     #[arg(help_heading = "REQUEST", long = "vhost")]
     pub vhost: Option<String>,
 
+    /// Read a raw HTTP request from a file and use it as the request template
+    #[arg(help_heading = "REQUEST", long = "raw-request", value_name = "FILE")]
+    pub raw_request: Option<String>,
+
+    /// Scheme for --raw-request when the request line is origin-form (http or https)
+    #[arg(
+        help_heading = "REQUEST",
+        long = "raw-request-proto",
+        value_name = "SCHEME",
+        default_value = "https"
+    )]
+    pub raw_request_proto: String,
+
     /// Fetch and append cookies from initial request
     #[arg(help_heading = "REQUEST", long = "cookies", action = clap::ArgAction::SetTrue)]
     pub use_cookies: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,7 +71,8 @@ pub struct Cli {
         long = "raw-request-proto",
         value_name = "SCHEME",
         default_value = "https",
-        requires = "raw_request"
+        requires = "raw_request",
+        value_parser = ["http", "https"]
     )]
     pub raw_request_proto: String,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,6 @@ pub mod model;
 pub mod mutator;
 pub mod output;
 pub mod payloads;
+pub mod raw_request;
 pub mod scanner;
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use url::Url;
 
 use smugglex::cli::Cli;
-use smugglex::error::Result;
+use smugglex::error::{Result, SmugglexError};
 use smugglex::exploit::{
     LocalhostAccessParams, PathFuzzParams, VulnerabilityContext, extract_vulnerability_context,
     get_fuzz_paths, print_localhost_results, print_path_fuzz_results, test_localhost_access,
@@ -23,6 +23,7 @@ use smugglex::payloads::{
     get_cl_edge_case_payloads, get_cl_te_payloads, get_h2_payloads, get_h2c_payloads,
     get_te_cl_payloads, get_te_te_payloads,
 };
+use smugglex::raw_request::parse_raw_request;
 use smugglex::scanner::{CheckParams, run_checks_for_type};
 use smugglex::utils::{LogLevel, fetch_cookies, is_machine, log, set_machine};
 
@@ -80,7 +81,7 @@ impl ScanOutcome {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let cli = Cli::parse();
+    let mut cli = Cli::parse();
     cli.apply_global_settings();
 
     // Activate machine mode for clean structured output (used by AI agents, scripts, CI).
@@ -96,35 +97,16 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    let urls = resolve_urls(&cli)?;
-    if urls.is_empty() {
-        if cli.effective_format().is_json() {
-            // Produce a valid (empty) JSON envelope even on input error so AI agents can parse uniformly.
-            let empty_batch = build_batch_results(Vec::new(), Some(env!("CARGO_PKG_VERSION")));
-            match serde_json::to_string_pretty(&empty_batch) {
-                Ok(json) => println!("{}", json),
-                Err(e) => {
-                    log(
-                        LogLevel::Error,
-                        &format!("failed to serialize empty batch results: {}", e),
-                    );
-                    println!(
-                        "{}",
-                        serde_json::json!({
-                            "results": [],
-                            "summary": {
-                                "total_targets": 0,
-                                "vulnerable_targets": 0,
-                                "total_checks": 0,
-                                "vulnerable_checks": 0
-                            }
-                        })
-                    );
-                }
-            }
-        } else {
-            eprintln!("{} No valid URLs provided", "[!]".yellow().bold());
+    let urls = match resolve_urls(&mut cli) {
+        Ok(urls) => urls,
+        Err(e) => {
+            emit_input_error(&cli, &e.to_string());
+            // Usage/input error → exit 2 (common convention for CLI tools)
+            std::process::exit(2);
         }
+    };
+    if urls.is_empty() {
+        emit_input_error(&cli, "No valid URLs provided");
         // Usage/input error → exit 2 (common convention for CLI tools)
         std::process::exit(2);
     }
@@ -229,7 +211,90 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn resolve_urls(cli: &Cli) -> Result<Vec<String>> {
+/// Emit an input/usage error consistently with the selected output format:
+/// a pure (empty) JSON envelope in machine mode so AI agents can parse uniformly,
+/// or a human-readable message otherwise. Callers exit with code 2 afterward.
+fn emit_input_error(cli: &Cli, message: &str) {
+    if cli.effective_format().is_json() {
+        let empty_batch = build_batch_results(Vec::new(), Some(env!("CARGO_PKG_VERSION")));
+        match serde_json::to_string_pretty(&empty_batch) {
+            Ok(json) => println!("{}", json),
+            Err(e) => {
+                log(
+                    LogLevel::Error,
+                    &format!("failed to serialize empty batch results: {}", e),
+                );
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "results": [],
+                        "summary": {
+                            "total_targets": 0,
+                            "vulnerable_targets": 0,
+                            "total_checks": 0,
+                            "vulnerable_checks": 0
+                        }
+                    })
+                );
+            }
+        }
+    } else {
+        eprintln!("{} {}", "[!]".yellow().bold(), message);
+    }
+}
+
+/// Load a `--raw-request` file and apply it as the request template: parse it,
+/// override the request fields the payload generators read (method, headers,
+/// Host), and return the synthetic target URL the scan pipeline consumes.
+fn apply_raw_request(cli: &mut Cli) -> Result<String> {
+    let path = cli
+        .raw_request
+        .clone()
+        .expect("apply_raw_request called without --raw-request");
+    let content = std::fs::read_to_string(&path).map_err(|e| {
+        SmugglexError::Io(format!("failed to read raw request file '{}': {}", path, e))
+    })?;
+    let raw = parse_raw_request(&content)?;
+
+    // Absolute-form request lines carry their own scheme; otherwise honor --raw-request-proto.
+    let scheme = match raw.scheme {
+        Some(scheme) => scheme,
+        None => {
+            let proto = cli.raw_request_proto.to_ascii_lowercase();
+            if proto != "http" && proto != "https" {
+                return Err(SmugglexError::InvalidInput(format!(
+                    "invalid --raw-request-proto '{}' (expected 'http' or 'https')",
+                    cli.raw_request_proto
+                )));
+            }
+            proto
+        }
+    };
+    let use_tls = scheme == "https";
+    let port = raw.port.unwrap_or(if use_tls { 443 } else { 80 });
+
+    // Feed the captured request into the same fields the payload builders read.
+    cli.method = raw.method;
+    cli.headers = raw.headers;
+    // Preserve the exact Host header (including any :port) unless --vhost was set explicitly.
+    if cli.vhost.is_none() {
+        cli.vhost = Some(raw.host_header);
+    }
+
+    Ok(format!("{}://{}:{}{}", scheme, raw.host, port, raw.target))
+}
+
+fn resolve_urls(cli: &mut Cli) -> Result<Vec<String>> {
+    if cli.raw_request.is_some() {
+        if !cli.urls.is_empty() {
+            return Err(SmugglexError::InvalidInput(
+                "--raw-request cannot be combined with target URLs; the target is taken from the request file".to_string(),
+            ));
+        }
+        let target = apply_raw_request(cli)?;
+        return Ok(vec![target]);
+    }
+
     if !cli.urls.is_empty() {
         Ok(cli.urls.clone())
     } else if !io::stdin().is_terminal() {
@@ -288,7 +353,15 @@ async fn scan_one_target(target: String, cli: Cli) -> ScanOutcome {
         Some(p) => p,
         None => return scan_failure("Invalid port in URL".to_string()),
     };
-    let path = url.path();
+    // Preserve any query string so raw-request templates (and normal URLs) keep
+    // their full request-target, not just the path.
+    let path_with_query;
+    let path = if let Some(query) = url.query() {
+        path_with_query = format!("{}?{}", url.path(), query);
+        path_with_query.as_str()
+    } else {
+        url.path()
+    };
     let use_tls = url.scheme() == "https";
     let host_header = cli.vhost.as_deref().unwrap_or(host);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,20 +256,9 @@ fn apply_raw_request(cli: &mut Cli) -> Result<String> {
     })?;
     let raw = parse_raw_request(&content)?;
 
-    // Absolute-form request lines carry their own scheme; otherwise honor --raw-request-proto.
-    let scheme = match raw.scheme {
-        Some(scheme) => scheme,
-        None => {
-            let proto = cli.raw_request_proto.to_ascii_lowercase();
-            if proto != "http" && proto != "https" {
-                return Err(SmugglexError::InvalidInput(format!(
-                    "invalid --raw-request-proto '{}' (expected 'http' or 'https')",
-                    cli.raw_request_proto
-                )));
-            }
-            proto
-        }
-    };
+    // Absolute-form request lines carry their own scheme; otherwise honor
+    // --raw-request-proto (already validated to http/https at the clap layer).
+    let scheme = raw.scheme.unwrap_or_else(|| cli.raw_request_proto.clone());
     let use_tls = scheme == "https";
     let port = raw.port.unwrap_or(if use_tls { 443 } else { 80 });
 

--- a/src/raw_request.rs
+++ b/src/raw_request.rs
@@ -101,6 +101,16 @@ fn parse_origin_form(
     host_header: Option<String>,
     headers: Vec<String>,
 ) -> Result<RawRequest> {
+    // Only origin-form targets (`/path?query`) are usable as a smuggling
+    // template. Reject authority-form (`CONNECT host:port`) and asterisk-form
+    // (`OPTIONS *`) request lines, which would otherwise be concatenated into an
+    // invalid synthetic URL downstream.
+    if !target.starts_with('/') {
+        return Err(SmugglexError::InvalidInput(format!(
+            "unsupported request target '{}' (expected an absolute path like '/path' or an absolute URL)",
+            target
+        )));
+    }
     let host_header = host_header.ok_or_else(|| {
         SmugglexError::InvalidInput(
             "raw request is missing a Host header (required to determine the target)".to_string(),
@@ -128,8 +138,10 @@ fn parse_absolute_form(
 ) -> Result<RawRequest> {
     let url = url::Url::parse(target_raw)
         .map_err(|e| SmugglexError::InvalidInput(format!("invalid request target: {}", e)))?;
+    // Use `host()` (not `host_str()`) so IPv6 literals keep their brackets
+    // (`[::1]`); the unbracketed form would build invalid URLs and Host headers.
     let host = url
-        .host_str()
+        .host()
         .ok_or_else(|| SmugglexError::InvalidInput("request target has no host".to_string()))?
         .to_string();
     let port = url.port();
@@ -282,6 +294,35 @@ mod tests {
         assert_eq!(parsed.scheme, Some("https".to_string()));
         assert_eq!(parsed.target, "/v1/users?id=7");
         assert_eq!(parsed.host_header, "api.example.com:8443");
+    }
+
+    #[test]
+    fn parses_absolute_form_ipv6_request_line() {
+        let raw = "GET http://[::1]:8080/health?ok=1 HTTP/1.1\r\n\
+                   Accept: */*\r\n\
+                   \r\n";
+        let parsed = parse_raw_request(raw).unwrap();
+        // IPv6 literals keep their brackets so the synthetic URL and emitted
+        // Host header are valid.
+        assert_eq!(parsed.host, "[::1]");
+        assert_eq!(parsed.port, Some(8080));
+        assert_eq!(parsed.scheme, Some("http".to_string()));
+        assert_eq!(parsed.target, "/health?ok=1");
+        assert_eq!(parsed.host_header, "[::1]:8080");
+    }
+
+    #[test]
+    fn errors_on_authority_form_target() {
+        let raw = "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        let err = parse_raw_request(raw).unwrap_err();
+        assert!(matches!(err, SmugglexError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn errors_on_asterisk_form_target() {
+        let raw = "OPTIONS * HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        let err = parse_raw_request(raw).unwrap_err();
+        assert!(matches!(err, SmugglexError::InvalidInput(_)));
     }
 
     #[test]

--- a/src/raw_request.rs
+++ b/src/raw_request.rs
@@ -171,8 +171,12 @@ fn parse_absolute_form(
 
 /// Whether a request-target is absolute-form (carries its own scheme).
 fn is_absolute_form(target: &str) -> bool {
-    let lower = target.to_ascii_lowercase();
-    lower.starts_with("http://") || lower.starts_with("https://")
+    let starts_with_ci = |prefix: &str| {
+        target
+            .get(..prefix.len())
+            .is_some_and(|head| head.eq_ignore_ascii_case(prefix))
+    };
+    starts_with_ci("http://") || starts_with_ci("https://")
 }
 
 /// Whether a header is one smugglex sets/controls itself for smuggling payloads.
@@ -251,6 +255,17 @@ mod tests {
         assert_eq!(parsed.port, Some(8443));
         // The emitted Host header keeps the port intact.
         assert_eq!(parsed.host_header, "example.com:8443");
+    }
+
+    #[test]
+    fn extracts_bracketed_ipv6_host_from_origin_form() {
+        let raw = "GET /status HTTP/1.1\r\nHost: [::1]:8080\r\n\r\n";
+        let parsed = parse_raw_request(raw).unwrap();
+        // Brackets are preserved so the synthetic URL `https://[::1]:8080/...`
+        // and the emitted Host header stay valid.
+        assert_eq!(parsed.host, "[::1]");
+        assert_eq!(parsed.port, Some(8080));
+        assert_eq!(parsed.host_header, "[::1]:8080");
     }
 
     #[test]

--- a/src/raw_request.rs
+++ b/src/raw_request.rs
@@ -1,0 +1,326 @@
+//! Parsing of raw HTTP requests supplied via `--raw-request <FILE>`.
+//!
+//! A raw request file is the kind of artifact you get from "Copy to file" in
+//! Burp Suite or a captured proxy log: a request line, a block of headers, an
+//! empty line, and an optional body. smugglex uses such a file as a *template*
+//! for the request it crafts — method, request-target, Host and the remaining
+//! headers (cookies, auth tokens, content-type, ...) are reused, while the body
+//! is discarded because the smuggling payloads generate their own body and
+//! manage `Content-Length` / `Transfer-Encoding` themselves.
+
+use crate::error::{Result, SmugglexError};
+
+/// Headers that the smuggling payload generators add or control on their own.
+/// They are stripped from a raw request so we never emit duplicates or fight
+/// the crafted `Content-Length` / `Transfer-Encoding` desync vectors.
+const MANAGED_HEADERS: [&str; 4] = ["host", "content-length", "transfer-encoding", "connection"];
+
+/// A raw HTTP request parsed from a file, reduced to the pieces smugglex reuses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawRequest {
+    /// HTTP method from the request line (e.g. `GET`, `POST`).
+    pub method: String,
+    /// Request-target including any query string (e.g. `/search?q=1`).
+    pub target: String,
+    /// Connection host (from the Host header, or from an absolute-form request line).
+    pub host: String,
+    /// Connection port, when explicitly present; otherwise derived from the scheme.
+    pub port: Option<u16>,
+    /// Scheme override for absolute-form request lines (`http`/`https`).
+    /// `None` for origin-form requests, where the caller applies `--raw-request-proto`.
+    pub scheme: Option<String>,
+    /// Exact `Host` header value to emit, preserving any `:port` suffix.
+    pub host_header: String,
+    /// Remaining headers as `Name: Value`, with [`MANAGED_HEADERS`] stripped out.
+    pub headers: Vec<String>,
+}
+
+/// Parse the textual contents of a raw HTTP request file.
+///
+/// Accepts both `\r\n` and bare `\n` line endings. The request body (anything
+/// after the first blank line) is intentionally ignored. Origin-form requests
+/// require a `Host` header to determine the target; absolute-form request lines
+/// (`GET https://host/path HTTP/1.1`) derive the host, port and scheme from the
+/// line itself.
+pub fn parse_raw_request(content: &str) -> Result<RawRequest> {
+    let mut lines = content.split('\n').map(|l| l.trim_end_matches('\r'));
+
+    let request_line = lines
+        .by_ref()
+        .find(|l| !l.trim().is_empty())
+        .ok_or_else(|| SmugglexError::InvalidInput("raw request file is empty".to_string()))?;
+
+    let mut parts = request_line.split_whitespace();
+    let method = parts
+        .next()
+        .ok_or_else(|| SmugglexError::InvalidInput("raw request missing method".to_string()))?
+        .to_string();
+    let target_raw = parts
+        .next()
+        .ok_or_else(|| {
+            SmugglexError::InvalidInput("raw request missing request target".to_string())
+        })?
+        .to_string();
+
+    // Headers run until the first blank line; everything after is the body.
+    let mut headers: Vec<String> = Vec::new();
+    let mut host_header: Option<String> = None;
+    for line in lines {
+        if line.trim().is_empty() {
+            break;
+        }
+        let Some((name, value)) = line.split_once(':') else {
+            // Not a well-formed header line (e.g. an obsolete folded continuation);
+            // skip it rather than emitting something malformed.
+            continue;
+        };
+        let name = name.trim();
+        let value = value.trim();
+        if name.eq_ignore_ascii_case("host") {
+            host_header = Some(value.to_string());
+            continue;
+        }
+        if is_managed_header(name) {
+            continue;
+        }
+        headers.push(format!("{}: {}", name, value));
+    }
+
+    if is_absolute_form(&target_raw) {
+        parse_absolute_form(method, &target_raw, host_header, headers)
+    } else {
+        parse_origin_form(method, target_raw, host_header, headers)
+    }
+}
+
+/// Build a [`RawRequest`] from an origin-form request line (`/path?query`),
+/// taking the target host from the mandatory `Host` header.
+fn parse_origin_form(
+    method: String,
+    target: String,
+    host_header: Option<String>,
+    headers: Vec<String>,
+) -> Result<RawRequest> {
+    let host_header = host_header.ok_or_else(|| {
+        SmugglexError::InvalidInput(
+            "raw request is missing a Host header (required to determine the target)".to_string(),
+        )
+    })?;
+    let (host, port) = split_host_port(&host_header);
+    Ok(RawRequest {
+        method,
+        target,
+        host,
+        port,
+        scheme: None,
+        host_header,
+        headers,
+    })
+}
+
+/// Build a [`RawRequest`] from an absolute-form request line
+/// (`http(s)://host[:port]/path?query`), deriving host, port and scheme from it.
+fn parse_absolute_form(
+    method: String,
+    target_raw: &str,
+    host_header: Option<String>,
+    headers: Vec<String>,
+) -> Result<RawRequest> {
+    let url = url::Url::parse(target_raw)
+        .map_err(|e| SmugglexError::InvalidInput(format!("invalid request target: {}", e)))?;
+    let host = url
+        .host_str()
+        .ok_or_else(|| SmugglexError::InvalidInput("request target has no host".to_string()))?
+        .to_string();
+    let port = url.port();
+
+    let mut target = url.path().to_string();
+    if let Some(query) = url.query() {
+        target.push('?');
+        target.push_str(query);
+    }
+
+    // Prefer an explicit Host header; otherwise reconstruct it from the URL.
+    let host_header = host_header.unwrap_or_else(|| match port {
+        Some(p) => format!("{}:{}", host, p),
+        None => host.clone(),
+    });
+
+    Ok(RawRequest {
+        method,
+        target,
+        host,
+        port,
+        scheme: Some(url.scheme().to_string()),
+        host_header,
+        headers,
+    })
+}
+
+/// Whether a request-target is absolute-form (carries its own scheme).
+fn is_absolute_form(target: &str) -> bool {
+    let lower = target.to_ascii_lowercase();
+    lower.starts_with("http://") || lower.starts_with("https://")
+}
+
+/// Whether a header is one smugglex sets/controls itself for smuggling payloads.
+fn is_managed_header(name: &str) -> bool {
+    MANAGED_HEADERS
+        .iter()
+        .any(|managed| name.eq_ignore_ascii_case(managed))
+}
+
+/// Split a `Host` header value into host and optional port.
+///
+/// Only a trailing all-numeric segment is treated as a port, so unbracketed
+/// values are not mistaken for ports. Bracketed IPv6 literals such as
+/// `[::1]:8080` are split correctly; the brackets are preserved on the host.
+fn split_host_port(host_value: &str) -> (String, Option<u16>) {
+    match host_value.rsplit_once(':') {
+        Some((host, port))
+            if !host.is_empty() && !port.is_empty() && port.chars().all(|c| c.is_ascii_digit()) =>
+        {
+            (host.to_string(), port.parse::<u16>().ok())
+        }
+        _ => (host_value.to_string(), None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_origin_form_post() {
+        let raw = "POST /search HTTP/1.1\r\n\
+                   Host: example.com\r\n\
+                   User-Agent: curl/8.0\r\n\
+                   Content-Type: application/x-www-form-urlencoded\r\n\
+                   Content-Length: 6\r\n\
+                   \r\n\
+                   q=test";
+        let parsed = parse_raw_request(raw).unwrap();
+        assert_eq!(parsed.method, "POST");
+        assert_eq!(parsed.target, "/search");
+        assert_eq!(parsed.host, "example.com");
+        assert_eq!(parsed.port, None);
+        assert_eq!(parsed.scheme, None);
+        assert_eq!(parsed.host_header, "example.com");
+        // Host and Content-Length are stripped; the rest is preserved in order.
+        assert_eq!(
+            parsed.headers,
+            vec![
+                "User-Agent: curl/8.0".to_string(),
+                "Content-Type: application/x-www-form-urlencoded".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn preserves_query_string() {
+        let raw = "GET /a/b?x=1&y=2 HTTP/1.1\nHost: example.com\n\n";
+        let parsed = parse_raw_request(raw).unwrap();
+        assert_eq!(parsed.method, "GET");
+        assert_eq!(parsed.target, "/a/b?x=1&y=2");
+    }
+
+    #[test]
+    fn handles_bare_lf_line_endings() {
+        let raw = "GET / HTTP/1.1\nHost: example.com\nAccept: */*\n\n";
+        let parsed = parse_raw_request(raw).unwrap();
+        assert_eq!(parsed.headers, vec!["Accept: */*".to_string()]);
+    }
+
+    #[test]
+    fn extracts_host_with_port() {
+        let raw = "GET / HTTP/1.1\r\nHost: example.com:8443\r\n\r\n";
+        let parsed = parse_raw_request(raw).unwrap();
+        assert_eq!(parsed.host, "example.com");
+        assert_eq!(parsed.port, Some(8443));
+        // The emitted Host header keeps the port intact.
+        assert_eq!(parsed.host_header, "example.com:8443");
+    }
+
+    #[test]
+    fn strips_managed_headers_case_insensitively() {
+        let raw = "POST / HTTP/1.1\r\n\
+                   Host: example.com\r\n\
+                   connection: close\r\n\
+                   TRANSFER-ENCODING: chunked\r\n\
+                   content-length: 0\r\n\
+                   X-Real: keep\r\n\
+                   \r\n";
+        let parsed = parse_raw_request(raw).unwrap();
+        assert_eq!(parsed.headers, vec!["X-Real: keep".to_string()]);
+    }
+
+    #[test]
+    fn keeps_cookie_and_authorization_headers() {
+        let raw = "GET / HTTP/1.1\r\n\
+                   Host: example.com\r\n\
+                   Cookie: session=abc; theme=dark\r\n\
+                   Authorization: Bearer t0ken\r\n\
+                   \r\n";
+        let parsed = parse_raw_request(raw).unwrap();
+        assert_eq!(
+            parsed.headers,
+            vec![
+                "Cookie: session=abc; theme=dark".to_string(),
+                "Authorization: Bearer t0ken".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_absolute_form_request_line() {
+        let raw = "GET https://api.example.com:8443/v1/users?id=7 HTTP/1.1\r\n\
+                   Accept: application/json\r\n\
+                   \r\n";
+        let parsed = parse_raw_request(raw).unwrap();
+        assert_eq!(parsed.host, "api.example.com");
+        assert_eq!(parsed.port, Some(8443));
+        assert_eq!(parsed.scheme, Some("https".to_string()));
+        assert_eq!(parsed.target, "/v1/users?id=7");
+        assert_eq!(parsed.host_header, "api.example.com:8443");
+    }
+
+    #[test]
+    fn absolute_form_prefers_explicit_host_header() {
+        let raw = "GET http://backend.internal/admin HTTP/1.1\r\n\
+                   Host: frontend.example.com\r\n\
+                   \r\n";
+        let parsed = parse_raw_request(raw).unwrap();
+        assert_eq!(parsed.host, "backend.internal");
+        assert_eq!(parsed.scheme, Some("http".to_string()));
+        assert_eq!(parsed.host_header, "frontend.example.com");
+    }
+
+    #[test]
+    fn errors_on_empty_input() {
+        let err = parse_raw_request("\n\n   \n").unwrap_err();
+        assert!(matches!(err, SmugglexError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn errors_when_origin_form_missing_host() {
+        let raw = "GET / HTTP/1.1\r\nAccept: */*\r\n\r\n";
+        let err = parse_raw_request(raw).unwrap_err();
+        assert!(matches!(err, SmugglexError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn split_host_port_ignores_non_numeric() {
+        assert_eq!(
+            split_host_port("example.com"),
+            ("example.com".to_string(), None)
+        );
+        assert_eq!(
+            split_host_port("example.com:443"),
+            ("example.com".to_string(), Some(443))
+        );
+        assert_eq!(
+            split_host_port("[::1]:8080"),
+            ("[::1]".to_string(), Some(8080))
+        );
+    }
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -542,3 +542,35 @@ fn test_exploit_path_fuzz_with_wordlist() {
         Some("/custom/wordlist.txt".to_string())
     );
 }
+
+#[test]
+fn test_raw_request_default_none() {
+    let cli = Cli::parse_from(["smugglex", "http://example.com"]);
+    assert_eq!(cli.raw_request, None);
+}
+
+#[test]
+fn test_raw_request_option() {
+    let cli = Cli::parse_from(["smugglex", "--raw-request", "request.txt"]);
+    assert_eq!(cli.raw_request, Some("request.txt".to_string()));
+    // The target comes from the request file, so no positional URL is required.
+    assert!(cli.urls.is_empty());
+}
+
+#[test]
+fn test_raw_request_proto_default_https() {
+    let cli = Cli::parse_from(["smugglex", "--raw-request", "request.txt"]);
+    assert_eq!(cli.raw_request_proto, "https");
+}
+
+#[test]
+fn test_raw_request_proto_override() {
+    let cli = Cli::parse_from([
+        "smugglex",
+        "--raw-request",
+        "request.txt",
+        "--raw-request-proto",
+        "http",
+    ]);
+    assert_eq!(cli.raw_request_proto, "http");
+}


### PR DESCRIPTION
## Summary

Closes #78.

Adds `--raw-request <FILE>` to read a raw HTTP request (e.g. exported from Burp Suite or a captured proxy log) and use it as the request **template**, instead of building the request from individual `-m` / `-H` / `--vhost` flags. This makes it easy to replicate complex captured traffic.

Companion flag: `--raw-request-proto <http|https>` — scheme to use when the request line is origin-form (default `https`, matching ffuf's `-request-proto`). Absolute-form request lines (`GET https://host/path HTTP/1.1`) derive the scheme/host/port directly.

## How it works

A new parser (`src/raw_request.rs`) extracts from the file:

- **method** + **request-target** (query string preserved)
- **Host header** → connection target (host\:port) and the exact `Host:` value to emit
- **remaining headers** (Cookie, Authorization, Content-Type, User-Agent, ...) → reused verbatim

Headers smugglex manages itself for the desync vectors — `Host`, `Connection`, `Content-Length`, `Transfer-Encoding` — are **stripped** so they aren't duplicated or in conflict with the crafted payloads. The request **body is discarded** because the smuggling payloads generate their own body.

The parsed values are injected into the existing `method` / `headers` / `vhost` fields, so **every payload generator reuses them unchanged** — no changes to the scanning pipeline. The exact Host header (including any `:port`) is preserved through the vhost mechanism.

### Example

Given `request.txt`:
```http
POST /search?q=hello HTTP/1.1
Host: target.example.com:8443
Cookie: session=abc123
Authorization: Bearer s3cr3t
Content-Type: application/x-www-form-urlencoded
Content-Length: 9

q=smuggle
```

`smugglex --raw-request request.txt` crafts (CL.TE example):
```http
POST /search?q=hello HTTP/1.1
Host: target.example.com:8443
Connection: keep-alive
Cookie: session=abc123
Authorization: Bearer s3cr3t
Content-Type: application/x-www-form-urlencoded
Content-Length: 6
Transfer-Encoding: chunked

0

G
```

## Notes / design choices

- `--raw-request` and positional target URLs are mutually exclusive (the target comes from the request file) → clear error, exit code 2.
- Origin-form requests require a `Host` header (needed to determine the target).
- Errors honor the output format: human message on stderr, or a valid empty JSON envelope in `--json` mode (exit 2).
- Also preserves query strings on the scan target generally (previously `?query` was dropped), and factors input-error emission into a shared `emit_input_error()` helper.

## Testing

- 11 new unit tests in `src/raw_request.rs` (origin/absolute form, query preservation, bare-LF endings, managed-header stripping, IPv6 host\:port split, error cases).
- 4 new CLI flag-parsing tests in `tests/cli_tests.rs`.
- Manual end-to-end smoke test against a local listener confirmed the crafted attack request matches the template.
- `cargo fmt --check`, `cargo clippy --all-targets`, full suite: **430 passed / 0 failed**.

## Docs

- README: usage snippet.
- `docs/content/usage/options.md`: options table + examples.
