### PR TITLE
fix(raw-request): preserve target verbatim, merge -H, warn on --method override

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ smugglex --raw-request request.txt --raw-request-proto http
 smugglex --raw-request request.txt -H "X-Collab: abcd.oastify.com"  # -H is additive
 ```
 
-The captured request-target is sent verbatim (dot-segments, matrix params and `#`
-are preserved, not normalized), and any `-H` headers are merged on top of the
-captured ones.
+For origin-form captures (`POST /path ...`, the usual Burp "copy to file" output)
+the request-target is sent verbatim — dot-segments, matrix params and `#` are
+preserved, not normalized — so path-based payloads survive. Any `-H` headers are
+merged on top of the captured ones. (Absolute-form request lines, `GET http://...`,
+still have their target normalized when parsed.)
 
 For detailed usage and options, see [Usage Guide](https://smugglex.hahwul.com/usage/).
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,12 @@ Replay a captured request (e.g. exported from Burp Suite) as the request templat
 ```bash
 smugglex --raw-request request.txt              # target taken from the Host header
 smugglex --raw-request request.txt --raw-request-proto http
+smugglex --raw-request request.txt -H "X-Collab: abcd.oastify.com"  # -H is additive
 ```
+
+The captured request-target is sent verbatim (dot-segments, matrix params and `#`
+are preserved, not normalized), and any `-H` headers are merged on top of the
+captured ones.
 
 For detailed usage and options, see [Usage Guide](https://smugglex.hahwul.com/usage/).
 

--- a/docs/content/usage/options.md
+++ b/docs/content/usage/options.md
@@ -71,13 +71,18 @@ smugglex -H "Authorization: Bearer token" -t 15 https://target.com
 
 # Replay a captured request (e.g. exported from Burp Suite) as the template.
 # Method, request-target, Host and headers (cookies, auth, ...) are reused;
-# the target is taken from the Host header. The body is replaced by the
-# generated smuggling payloads, and Content-Length / Transfer-Encoding are
-# managed by smugglex.
+# the target is taken from the Host header. The request-target is sent
+# verbatim — dot-segments, matrix params and '#' are preserved, not normalized
+# — so path-based payloads survive. The body is replaced by the generated
+# smuggling payloads, and Content-Length / Transfer-Encoding are managed by
+# smugglex.
 smugglex --raw-request request.txt
 
 # Same, but the captured request targets a plain-HTTP service
 smugglex --raw-request request.txt --raw-request-proto http
+
+# -H is additive on top of the captured headers (e.g. add a collaborator marker)
+smugglex --raw-request request.txt -H "X-Collab: abcd.oastify.com"
 
 # Route through a proxy (e.g., Burp Suite)
 smugglex -x http://127.0.0.1:8080 https://target.com

--- a/docs/content/usage/options.md
+++ b/docs/content/usage/options.md
@@ -71,11 +71,12 @@ smugglex -H "Authorization: Bearer token" -t 15 https://target.com
 
 # Replay a captured request (e.g. exported from Burp Suite) as the template.
 # Method, request-target, Host and headers (cookies, auth, ...) are reused;
-# the target is taken from the Host header. The request-target is sent
-# verbatim — dot-segments, matrix params and '#' are preserved, not normalized
-# — so path-based payloads survive. The body is replaced by the generated
-# smuggling payloads, and Content-Length / Transfer-Encoding are managed by
-# smugglex.
+# the target is taken from the Host header. For origin-form captures
+# (POST /path ...) the request-target is sent verbatim — dot-segments, matrix
+# params and '#' are preserved, not normalized — so path-based payloads survive.
+# (Absolute-form lines, GET http://..., still have their target normalized.)
+# The body is replaced by the generated smuggling payloads, and
+# Content-Length / Transfer-Encoding are managed by smugglex.
 smugglex --raw-request request.txt
 
 # Same, but the captured request targets a plain-HTTP service

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,11 @@ use clap::{Parser, ValueEnum};
 use colored::control;
 use std::fmt;
 
+/// Default method for the attack request. Kept as a named constant so the
+/// `--raw-request` override can tell whether the user explicitly set `--method`
+/// (anything other than this default) before warning about a conflict.
+pub const DEFAULT_METHOD: &str = "POST";
+
 /// Output format type
 #[derive(Debug, Clone, ValueEnum)]
 pub enum OutputFormat {
@@ -46,7 +51,7 @@ pub struct Cli {
     pub urls: Vec<String>,
 
     /// Custom method for the attack request
-    #[arg(help_heading = "REQUEST", short, long, default_value = "POST")]
+    #[arg(help_heading = "REQUEST", short, long, default_value = DEFAULT_METHOD)]
     pub method: String,
 
     /// Socket timeout in seconds
@@ -75,6 +80,13 @@ pub struct Cli {
         value_parser = ["http", "https"]
     )]
     pub raw_request_proto: String,
+
+    /// Literal request-target captured from `--raw-request`, applied verbatim so the
+    /// exact bytes (dot-segments, `#`, params) survive instead of being normalized by
+    /// re-parsing a synthetic URL. Not a user-facing flag; populated by the raw-request
+    /// pipeline.
+    #[arg(skip)]
+    pub raw_target: Option<String>,
 
     /// Fetch and append cookies from initial request
     #[arg(help_heading = "REQUEST", long = "cookies", action = clap::ArgAction::SetTrue)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use smugglex::payloads::{
     get_cl_edge_case_payloads, get_cl_te_payloads, get_h2_payloads, get_h2c_payloads,
     get_te_cl_payloads, get_te_te_payloads,
 };
-use smugglex::raw_request::parse_raw_request;
+use smugglex::raw_request::{merge_headers, parse_raw_request};
 use smugglex::scanner::{CheckParams, run_checks_for_type};
 use smugglex::utils::{LogLevel, fetch_cookies, is_machine, log, set_machine};
 
@@ -277,9 +277,8 @@ fn apply_raw_request(cli: &mut Cli) -> Result<String> {
     cli.method = raw.method;
     // Merge headers additively: captured headers first, then any user-supplied -H,
     // so an explicit -H (e.g. a collaborator marker) is never silently dropped.
-    let mut headers = raw.headers;
-    headers.extend(std::mem::take(&mut cli.headers));
-    cli.headers = headers;
+    let user_headers = std::mem::take(&mut cli.headers);
+    cli.headers = merge_headers(raw.headers, &user_headers);
     // Apply the request-target verbatim downstream (no URL normalization).
     cli.raw_target = Some(raw.target);
     // Preserve the exact Host header (including any :port) unless --vhost was set explicitly.

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,21 +256,38 @@ fn apply_raw_request(cli: &mut Cli) -> Result<String> {
     })?;
     let raw = parse_raw_request(&content)?;
 
-    // Absolute-form request lines carry their own scheme; otherwise honor
-    // --raw-request-proto (already validated to http/https at the clap layer).
-    let scheme = raw.scheme.unwrap_or_else(|| cli.raw_request_proto.clone());
-    let use_tls = scheme == "https";
-    let port = raw.port.unwrap_or(if use_tls { 443 } else { 80 });
+    // Connection target only (scheme/host/port). The request-target is applied
+    // separately and verbatim via cli.raw_target so its exact bytes survive.
+    let connect_url = raw.connect_url(&cli.raw_request_proto);
+
+    // The captured request's method wins, so warn if the user also passed an
+    // explicit --method (anything other than the default) that we're discarding.
+    let user_set_method = cli.method != smugglex::cli::DEFAULT_METHOD;
+    if user_set_method && cli.method != raw.method && !is_machine() {
+        log(
+            LogLevel::Warning,
+            &format!(
+                "--method {} is ignored; the captured request method {} (from --raw-request) is used instead",
+                cli.method, raw.method
+            ),
+        );
+    }
 
     // Feed the captured request into the same fields the payload builders read.
     cli.method = raw.method;
-    cli.headers = raw.headers;
+    // Merge headers additively: captured headers first, then any user-supplied -H,
+    // so an explicit -H (e.g. a collaborator marker) is never silently dropped.
+    let mut headers = raw.headers;
+    headers.extend(std::mem::take(&mut cli.headers));
+    cli.headers = headers;
+    // Apply the request-target verbatim downstream (no URL normalization).
+    cli.raw_target = Some(raw.target);
     // Preserve the exact Host header (including any :port) unless --vhost was set explicitly.
     if cli.vhost.is_none() {
         cli.vhost = Some(raw.host_header);
     }
 
-    Ok(format!("{}://{}:{}{}", scheme, raw.host, port, raw.target))
+    Ok(connect_url)
 }
 
 fn resolve_urls(cli: &mut Cli) -> Result<Vec<String>> {
@@ -343,9 +360,14 @@ async fn scan_one_target(target: String, cli: Cli) -> ScanOutcome {
         None => return scan_failure("Invalid port in URL".to_string()),
     };
     // Preserve any query string so raw-request templates (and normal URLs) keep
-    // their full request-target, not just the path.
+    // their full request-target, not just the path. A --raw-request capture carries
+    // its literal request-target in cli.raw_target so the exact bytes (dot-segments,
+    // `#`, matrix params) bypass the URL normalization the synthetic connect URL went
+    // through.
     let path_with_query;
-    let path = if let Some(query) = url.query() {
+    let path = if let Some(ref raw_target) = cli.raw_target {
+        raw_target.as_str()
+    } else if let Some(query) = url.query() {
         path_with_query = format!("{}?{}", url.path(), query);
         path_with_query.as_str()
     } else {

--- a/src/raw_request.rs
+++ b/src/raw_request.rs
@@ -54,6 +54,18 @@ impl RawRequest {
     }
 }
 
+/// Merge captured headers with user-supplied `-H` headers.
+///
+/// Captured headers come first (preserving the template order), then the user's
+/// `-H` headers are appended so an explicit `-H` is *additive* and never silently
+/// dropped. Overlapping names are intentionally kept as duplicates rather than
+/// de-duplicated: smuggling tests sometimes rely on header repetition, and we
+/// want to exercise the origin server's own first/last precedence.
+pub fn merge_headers(mut captured: Vec<String>, user: &[String]) -> Vec<String> {
+    captured.extend(user.iter().cloned());
+    captured
+}
+
 /// Parse the textual contents of a raw HTTP request file.
 ///
 /// Accepts both `\r\n` and bare `\n` line endings. The request body (anything
@@ -381,6 +393,41 @@ mod tests {
         let raw = "GET / HTTP/1.1\r\nAccept: */*\r\n\r\n";
         let err = parse_raw_request(raw).unwrap_err();
         assert!(matches!(err, SmugglexError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn merge_headers_appends_user_after_captured() {
+        let captured = vec!["Cookie: a=1".to_string(), "Accept: */*".to_string()];
+        let user = vec!["X-Collab: marker".to_string()];
+        assert_eq!(
+            merge_headers(captured, &user),
+            vec![
+                "Cookie: a=1".to_string(),
+                "Accept: */*".to_string(),
+                "X-Collab: marker".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_headers_no_user_headers_is_identity() {
+        let captured = vec!["Cookie: a=1".to_string()];
+        assert_eq!(merge_headers(captured.clone(), &[]), captured);
+    }
+
+    #[test]
+    fn merge_headers_keeps_overlapping_names_as_duplicates() {
+        // An explicit -H that overlaps a captured header must NOT replace it;
+        // both are emitted so header-repetition tests still work.
+        let captured = vec!["User-Agent: captured".to_string()];
+        let user = vec!["User-Agent: override".to_string()];
+        assert_eq!(
+            merge_headers(captured, &user),
+            vec![
+                "User-Agent: captured".to_string(),
+                "User-Agent: override".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/src/raw_request.rs
+++ b/src/raw_request.rs
@@ -35,6 +35,25 @@ pub struct RawRequest {
     pub headers: Vec<String>,
 }
 
+impl RawRequest {
+    /// Build the synthetic URL used purely to derive the *connection* target
+    /// (scheme, host, port) — its path is always `/`.
+    ///
+    /// The real request-target ([`RawRequest::target`]) is applied separately and
+    /// verbatim downstream, so embedding it here is intentionally avoided: routing
+    /// it through `Url::parse` would normalize dot-segments (`/a/../b` → `/b`) and
+    /// drop anything after a `#`, mangling path-based smuggling payloads.
+    ///
+    /// `proto_default` (from `--raw-request-proto`) supplies the scheme for
+    /// origin-form requests, which carry none of their own.
+    pub fn connect_url(&self, proto_default: &str) -> String {
+        let scheme = self.scheme.as_deref().unwrap_or(proto_default);
+        let use_tls = scheme == "https";
+        let port = self.port.unwrap_or(if use_tls { 443 } else { 80 });
+        format!("{}://{}:{}/", scheme, self.host, port)
+    }
+}
+
 /// Parse the textual contents of a raw HTTP request file.
 ///
 /// Accepts both `\r\n` and bare `\n` line endings. The request body (anything
@@ -362,6 +381,44 @@ mod tests {
         let raw = "GET / HTTP/1.1\r\nAccept: */*\r\n\r\n";
         let err = parse_raw_request(raw).unwrap_err();
         assert!(matches!(err, SmugglexError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn connect_url_origin_form_uses_default_proto_and_port() {
+        let raw = parse_raw_request("GET /a HTTP/1.1\r\nHost: example.com\r\n\r\n").unwrap();
+        // Origin-form carries no scheme: --raw-request-proto decides it (and the port).
+        assert_eq!(raw.connect_url("https"), "https://example.com:443/");
+        assert_eq!(raw.connect_url("http"), "http://example.com:80/");
+    }
+
+    #[test]
+    fn connect_url_keeps_explicit_port() {
+        let raw = parse_raw_request("GET /a HTTP/1.1\r\nHost: example.com:8443\r\n\r\n").unwrap();
+        assert_eq!(raw.connect_url("https"), "https://example.com:8443/");
+    }
+
+    #[test]
+    fn connect_url_absolute_form_scheme_wins_over_default() {
+        let raw = parse_raw_request("GET http://api.example.com/x HTTP/1.1\r\nAccept: */*\r\n\r\n")
+            .unwrap();
+        // Absolute-form carries its own scheme; the proto default is ignored.
+        assert_eq!(raw.connect_url("https"), "http://api.example.com:80/");
+    }
+
+    #[test]
+    fn connect_url_path_is_always_root() {
+        // The real request-target lives in `target`; connect_url must never embed it,
+        // so dot-segments and fragments can't be normalized away by URL re-parsing.
+        let raw =
+            parse_raw_request("GET /a/../b#frag?x=1 HTTP/1.1\r\nHost: h.test\r\n\r\n").unwrap();
+        assert_eq!(raw.connect_url("https"), "https://h.test:443/");
+        assert_eq!(raw.target, "/a/../b#frag?x=1");
+    }
+
+    #[test]
+    fn connect_url_bracketed_ipv6() {
+        let raw = parse_raw_request("GET /a HTTP/1.1\r\nHost: [::1]:8080\r\n\r\n").unwrap();
+        assert_eq!(raw.connect_url("http"), "http://[::1]:8080/");
     }
 
     #[test]

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -558,6 +558,14 @@ fn test_raw_request_option() {
 }
 
 #[test]
+fn test_raw_target_not_a_user_flag_and_defaults_none() {
+    // raw_target is an internal (#[arg(skip)]) field, not a CLI flag.
+    let cli = Cli::parse_from(["smugglex", "http://example.com"]);
+    assert_eq!(cli.raw_target, None);
+    assert!(Cli::try_parse_from(["smugglex", "http://example.com", "--raw-target", "/x"]).is_err());
+}
+
+#[test]
 fn test_raw_request_proto_default_https() {
     let cli = Cli::parse_from(["smugglex", "--raw-request", "request.txt"]);
     assert_eq!(cli.raw_request_proto, "https");


### PR DESCRIPTION
## Summary

Follow-up to #101. End-to-end (wire-captured) testing of `--raw-request` surfaced four defects/limitations that broke the "replay a captured request faithfully" contract. This fixes all four.

| # | Issue | Severity | Status |
|---|-------|----------|--------|
| 1 | `-H` headers silently dropped when combined with `--raw-request` | High | ✅ fixed |
| 2 | request-target dot-segments normalized (`/a/../b` → `/b`) | High | ✅ fixed |
| 3 | `#` truncated the request-target (query after it lost too) | Med-High | ✅ fixed |
| 4 | explicit `--method` silently overridden by captured method | Med-Low | ✅ warn |

### 1. `-H` was clobbered
`apply_raw_request` did `cli.headers = raw.headers`, a full overwrite, so `--raw-request file -H "X-Collab: ..."` never sent `X-Collab`. Now headers merge additively: **captured headers first, then `-H`**.

### 2 & 3. Target was mangled by URL round-tripping
The target was embedded in a synthetic URL and re-extracted via `Url::parse` → `url.path()+query()`, which normalizes dot-segments and drops `#` fragments:

```
in:   /api/..%2f..%2fadmin/x;jsessionid=1/../y?q=a%20b
out:  /api/..%2f..%2fadmin/y?q=a%20b            ← matrix segment eaten by /../
in:   /admin#/../public?x=1
out:  /admin                                    ← everything after # lost
```

The synthetic URL is now built **for the connection target only** (scheme/host/port, root path) via `RawRequest::connect_url`; the literal request-target is carried through `cli.raw_target` and applied verbatim. After the fix both inputs above go on the wire byte-for-byte.

### 4. Silent `--method` override
The captured method still wins (as designed), but a non-default `--method` that conflicts now emits a warning. Guarded against false positives on the default `POST`, and suppressed in machine/JSON mode to keep stdout clean.

## Testing
- Verified all four on the wire with a local TCP capture server (origin-form Burp-style capture).
- `cargo test` — 162 pass (added `connect_url` unit tests + a CLI test for the internal `raw_target` field).
- `cargo clippy --all-targets` clean, `cargo fmt --check` clean.
- Machine mode (`--json`): stdout stays valid JSON, method warning routed away.

## Notes
- Absolute-form request lines still derive their path via `Url` at parse time (pre-existing); the verbatim guarantee covers origin-form captures, which is the dominant Burp "copy to file" case.
- A secondary observation (not fixed here): the timing baseline request uses the bare connect host and omits captured auth/cookies, so it can diverge from the attack request's Host/auth. Happy to address in a separate PR if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)