### PR TITLE
fix(raw-request): preserve absolute-form request-target verbatim

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,10 @@ smugglex --raw-request request.txt --raw-request-proto http
 smugglex --raw-request request.txt -H "X-Collab: abcd.oastify.com"  # -H is additive
 ```
 
-For origin-form captures (`POST /path ...`, the usual Burp "copy to file" output)
-the request-target is sent verbatim — dot-segments, matrix params and `#` are
-preserved, not normalized — so path-based payloads survive. Any `-H` headers are
-merged on top of the captured ones. (Absolute-form request lines, `GET http://...`,
-still have their target normalized when parsed.)
+The captured request-target is sent verbatim — dot-segments, matrix params and `#`
+are preserved, not normalized — for both origin-form (`POST /path ...`) and
+absolute-form (`GET http://...`) request lines, so path-based payloads survive.
+Any `-H` headers are merged on top of the captured ones.
 
 For detailed usage and options, see [Usage Guide](https://smugglex.hahwul.com/usage/).
 

--- a/docs/content/usage/options.md
+++ b/docs/content/usage/options.md
@@ -71,12 +71,11 @@ smugglex -H "Authorization: Bearer token" -t 15 https://target.com
 
 # Replay a captured request (e.g. exported from Burp Suite) as the template.
 # Method, request-target, Host and headers (cookies, auth, ...) are reused;
-# the target is taken from the Host header. For origin-form captures
-# (POST /path ...) the request-target is sent verbatim — dot-segments, matrix
-# params and '#' are preserved, not normalized — so path-based payloads survive.
-# (Absolute-form lines, GET http://..., still have their target normalized.)
-# The body is replaced by the generated smuggling payloads, and
-# Content-Length / Transfer-Encoding are managed by smugglex.
+# the target is taken from the Host header. The request-target is sent verbatim
+# — dot-segments, matrix params and '#' are preserved, not normalized — for both
+# origin-form (POST /path ...) and absolute-form (GET http://...) request lines,
+# so path-based payloads survive. The body is replaced by the generated smuggling
+# payloads, and Content-Length / Transfer-Encoding are managed by smugglex.
 smugglex --raw-request request.txt
 
 # Same, but the captured request targets a plain-HTTP service

--- a/src/raw_request.rs
+++ b/src/raw_request.rs
@@ -177,11 +177,23 @@ fn parse_absolute_form(
         .to_string();
     let port = url.port();
 
-    let mut target = url.path().to_string();
-    if let Some(query) = url.query() {
-        target.push('?');
-        target.push_str(query);
-    }
+    // Preserve the literal request-target (path + query + any fragment) verbatim
+    // rather than reading `url.path()`/`url.query()`, which normalize dot-segments
+    // (`/a/../b` → `/b`) and drop everything after `#`. Slice the original string
+    // from where the authority ends — the first `/`, `?` or `#` after the
+    // `scheme://` prefix — none of which can appear unescaped in the authority.
+    // `url.scheme()` is lowercased but the same length as the captured scheme, so
+    // the byte offset is correct even for `HTTP://`.
+    let after_scheme = &target_raw[url.scheme().len() + 3..];
+    let target = match after_scheme.find(['/', '?', '#']) {
+        // A real path: take it (and everything after) as-is.
+        Some(i) if after_scheme.as_bytes()[i] == b'/' => after_scheme[i..].to_string(),
+        // Query/fragment but no path (`http://host?q`): synthesize a root path so
+        // the request-target stays valid origin-form (`/?q`).
+        Some(i) => format!("/{}", &after_scheme[i..]),
+        // Authority only (`http://host`): default to root.
+        None => "/".to_string(),
+    };
 
     // Prefer an explicit Host header; otherwise reconstruct it from the URL.
     let host_header = host_header.unwrap_or_else(|| match port {
@@ -340,6 +352,57 @@ mod tests {
         assert_eq!(parsed.scheme, Some("https".to_string()));
         assert_eq!(parsed.target, "/v1/users?id=7");
         assert_eq!(parsed.host_header, "api.example.com:8443");
+    }
+
+    #[test]
+    fn absolute_form_preserves_dot_segments_and_fragment() {
+        // url.path()/url.query() would collapse `/../` and drop `#frag`; the literal
+        // slice must keep the request-target byte-for-byte.
+        let raw = "GET https://h.test/a/../b?x=1#frag HTTP/1.1\r\nAccept: */*\r\n\r\n";
+        let parsed = parse_raw_request(raw).unwrap();
+        assert_eq!(parsed.host, "h.test");
+        assert_eq!(parsed.target, "/a/../b?x=1#frag");
+    }
+
+    #[test]
+    fn absolute_form_preserves_encoded_and_matrix_params() {
+        let raw = "GET http://h/api/..%2fadmin/x;y=1/../z?q=a%20b HTTP/1.1\r\nAccept: */*\r\n\r\n";
+        let parsed = parse_raw_request(raw).unwrap();
+        assert_eq!(parsed.target, "/api/..%2fadmin/x;y=1/../z?q=a%20b");
+    }
+
+    #[test]
+    fn absolute_form_ipv6_preserves_dot_segments() {
+        let raw = "GET http://[::1]:8080/a/../b HTTP/1.1\r\nAccept: */*\r\n\r\n";
+        let parsed = parse_raw_request(raw).unwrap();
+        assert_eq!(parsed.host, "[::1]");
+        assert_eq!(parsed.port, Some(8080));
+        assert_eq!(parsed.target, "/a/../b");
+    }
+
+    #[test]
+    fn absolute_form_query_only_synthesizes_root_path() {
+        let raw = "GET http://h?q=1 HTTP/1.1\r\nAccept: */*\r\n\r\n";
+        let parsed = parse_raw_request(raw).unwrap();
+        assert_eq!(parsed.host, "h");
+        assert_eq!(parsed.target, "/?q=1");
+    }
+
+    #[test]
+    fn absolute_form_authority_only_defaults_to_root() {
+        let raw = "GET https://h HTTP/1.1\r\nAccept: */*\r\n\r\n";
+        let parsed = parse_raw_request(raw).unwrap();
+        assert_eq!(parsed.target, "/");
+    }
+
+    #[test]
+    fn absolute_form_with_userinfo_keeps_path_and_host() {
+        // Userinfo precedes the host but can't contain '/', so the first '/' still
+        // marks the request-target. The host (not the userinfo) is used downstream.
+        let raw = "GET http://user:pw@h.test/a/../b HTTP/1.1\r\nAccept: */*\r\n\r\n";
+        let parsed = parse_raw_request(raw).unwrap();
+        assert_eq!(parsed.host, "h.test");
+        assert_eq!(parsed.target, "/a/../b");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #102. #102 made the request-target verbatim for **origin-form** captures but left **absolute-form** request lines (`GET http://host/path ...`) still normalized — the same dot-segment / `#` defect, just on a different parse path. This closes that gap so the verbatim guarantee is universal.

(Supersedes the stacked PR #103, which auto-closed when its base branch was deleted on #102's squash-merge. This is the same commit rebased onto `main`.)

## The remaining defect (before)

`parse_absolute_form` built the target from `url.path()` + `url.query()`, which normalizes:

```
capture: GET http://127.0.0.1/a/../b?x=1#frag HTTP/1.1
on-wire: GET /b                     ← /../ collapsed, query + #frag dropped
```

## Fix

`url::Url` is still used to extract host/port/scheme robustly (handles IPv6 brackets and userinfo), but the **request-target is sliced verbatim** from the original string — from the first `/`, `?` or `#` after the `scheme://` prefix (none of which can appear unescaped in the authority; `url.scheme()` is lowercased but the same length as the captured scheme, so the byte offset holds even for `HTTP://`).

Edge handling:
- query/fragment with no path → synthesize root path (`http://h?q` → `/?q`)
- authority only → `/`

After:
```
capture: GET http://127.0.0.1/a/../b?x=1#frag HTTP/1.1
on-wire: GET /a/../b?x=1#frag       ✅ byte-for-byte
```

## Testing
- Wire-verified the exact previously-broken case against a local TCP capture server.
- Added unit tests: dot-segments+fragment, encoded/matrix params, IPv6 + dot-segments, query-only, authority-only, userinfo. Existing absolute-form tests still pass.
- `cargo test`, `cargo clippy --all-targets`, `cargo fmt --check` all clean.
- Removed the origin-form-only caveat from README/docs added in #102, since the guarantee now holds universally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)