### PR TITLE
fix(raw-request): report the real request-target, not the root connect URL

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -375,9 +375,22 @@ async fn scan_one_target(target: String, cli: Cli) -> ScanOutcome {
     let use_tls = url.scheme() == "https";
     let host_header = cli.vhost.as_deref().unwrap_or(host);
 
+    // What we report to the user/agent (logs, JSON `target`, output filenames).
+    // For a --raw-request capture, `target_url` is only the root-path connect URL,
+    // so reports would otherwise hide the actual endpoint; rebuild it from the
+    // literal request-target by concatenation (no URL re-parse, so the exact bytes
+    // survive). Normal URLs report `target_url` unchanged.
+    let display_target_owned;
+    let display_target: &str = if cli.raw_target.is_some() {
+        display_target_owned = format!("{}://{}:{}{}", url.scheme(), host, port, path);
+        &display_target_owned
+    } else {
+        target_url
+    };
+
     // Human logs only in plain mode
     if !is_machine() {
-        log(LogLevel::Info, &format!("start scan to {}", target_url));
+        log(LogLevel::Info, &format!("start scan to {}", display_target));
     }
 
     let cookies = if cli.use_cookies {
@@ -556,7 +569,7 @@ async fn scan_one_target(target: String, cli: Cli) -> ScanOutcome {
         log_scan_results(
             &results,
             &cli.effective_format(),
-            target_url,
+            display_target,
             &cli.method,
             &fingerprint_info,
         );
@@ -576,7 +589,7 @@ async fn scan_one_target(target: String, cli: Cli) -> ScanOutcome {
                 use_tls,
                 timeout: cli.timeout,
                 verbose: cli.verbose,
-                target_url,
+                target_url: display_target,
                 ports_str: &cli.exploit_ports,
                 wordlist_path: cli.exploit_wordlist.as_deref(),
                 delay: cli.delay,
@@ -603,7 +616,7 @@ async fn scan_one_target(target: String, cli: Cli) -> ScanOutcome {
         && let Some(ref output_file) = cli.output
         && let Err(e) = save_results_to_file(
             output_file,
-            target_url,
+            display_target,
             &cli.method,
             results.clone(),
             &fingerprint_info,
@@ -625,7 +638,7 @@ async fn scan_one_target(target: String, cli: Cli) -> ScanOutcome {
 
     // Build the structured result for the outcome (always produced, used for JSON batch or exit code)
     let scan_results = ScanResults {
-        target: target_url.to_string(),
+        target: display_target.to_string(),
         method: cli.method.clone(),
         timestamp: chrono::Utc::now().to_rfc3339(),
         fingerprint: fingerprint_info,
@@ -634,7 +647,7 @@ async fn scan_one_target(target: String, cli: Cli) -> ScanOutcome {
     };
 
     ScanOutcome::Success {
-        target: target_url.to_string(),
+        target: display_target.to_string(),
         scan_results,
         found_vulnerability,
     }


### PR DESCRIPTION
## Summary

Follow-up to #102 / #104. While auditing the merged `--raw-request` feature for further defects, found that scans **report the wrong target**.

#102 made the synthetic connect URL use a root path (`http://host:port/`) so the request-target could be sent unnormalized. But the reporting code kept using that connect URL as the target, so the actual endpoint was hidden everywhere user-/agent-facing:

```
capture: POST /api/search?q=secret&page=2  (Host: 127.0.0.1:9099)

before — JSON target:  "http://127.0.0.1:9099/"            ← path/query gone
after  — JSON target:  "http://127.0.0.1:9099/api/search?q=secret&page=2"
```

This matters because the tool's output feeds AI agents / scripts (cf. #99): the reported `target` couldn't be matched to the endpoint that was actually tested. Affected sinks: JSON `target`, the plain-mode `start scan to` log, the `-o` output file, and exploit banners.

## Fix

Add a `display_target` in `scan_one_target`, rebuilt by **concatenation** from the literal request-target (`{scheme}://{host}:{port}{path}` — no `Url` re-parse, so the exact bytes are preserved), and route all reporting through it. Normal (non-raw) scans keep reporting `target_url` unchanged. The on-wire request-target is untouched and still verbatim.

## Testing
- Wire + JSON verified: JSON `target` and `start scan to` now show `/api/search?q=secret&page=2`; the wire request-target is still byte-for-byte verbatim.
- Regression: a normal URL scan (`http://h/foo?a=1`) reports its target unchanged (no forced default `:port`, no normalization).
- `cargo test`, `cargo clippy --all-targets`, `cargo fmt --check` all clean.

## Other findings from the same audit (not fixed here — flagging for triage)
- **Low**: an out-of-range port in the `Host` header (e.g. `:99999`) is silently dropped and the scan falls back to the default port instead of erroring.
- **Low**: a non-HTTP file (e.g. an accidental JSON) yields a confusing `unsupported request target '"bar",'` rather than a "this doesn't look like an HTTP request" message.
- **Info**: the captured body is always discarded (by design — payloads generate their own); could be a `-V` note.

Happy to address any of these in a follow-up if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)