### PR TITLE
Detect second-request CL.TE desync; expand Crystal lab scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Added
+- Second-request desync detection: when a CL.TE/TE.CL/TE.TE check finds no direct anomaly, smugglex now plants a TE payload and probes fresh follow-up requests for structural divergence (non-5xx status or body) from the baseline, reproduced across two independent plant+probe sequences. This catches "second-request" smuggling where the attack response itself is a clean `200` and only the *following* request on the shared upstream connection is corrupted — including the real socket-level lab in `lab/desync/`, which was previously missed by the `cl-te` check. Surfaced via the new `second_request_desync` detection signal.
+- Lab harness scenarios (`lab/validate.cr`): three stateful `TP_second_request_*` true positives and three new false positives (`FP_followup_503_overload`, `FP_te_request_405`, `FP_transient_404`) guarding the new probe against 5xx overload, attack-response status differences, and non-recurring transients.
+
 ## 0.3.0
 
 ### Added

--- a/lab/README.md
+++ b/lab/README.md
@@ -44,6 +44,9 @@ cl-te --timeout 6 http://127.0.0.1:<port>/` against each and compares:
 | `FP_waf_blocks_te` | WAF returns 403 on TE shapes, 200 otherwise | Verifies the scanner does not over-interpret WAF-shaped status/body differences as smuggling |
 | `FP_natural_body_jitter` | Every response body varies ±4% (480–520 B) within similarity threshold | Body/follow-up divergence heuristics do not over-trigger on natural backend variability |
 | `FP_intermittent_504` | ~5% of post-baseline requests return 504 (realistic flake rate) | Strict-majority confirmation + all-retries-for-status-only suppress sparse intermittent failures. Pathologically high flake rates (≥20%) remain a known limitation. |
+| `FP_followup_503_overload` | Healthy during baseline, then every request (incl. follow-ups) returns 503 | The second-request probe ignores 5xx follow-up responses (overload/flake), so an overloaded upstream does not look like desync |
+| `FP_te_request_405` | Any request with a body (TE or non-zero CL) gets 405; plain GETs stay 200 | The attack response differing in status is not itself desync — the second-request probe only inspects *follow-up* responses, which stay clean |
+| `FP_transient_404` | A single, one-off 404 on the first follow-up GET that does not recur | The second-request probe requires divergence to reproduce across two independent plant+probe sequences, rejecting non-recurring transients |
 
 ### True positives (must flag)
 
@@ -53,10 +56,32 @@ cl-te --timeout 6 http://127.0.0.1:<port>/` against each and compares:
 | `TP_clte_timing` | TE-carrying requests are slow, all other shapes fast | `timing_anomaly` |
 | `TP_followup_desync` | Attack + control both slow with identical small body, but post-attack GETs return a divergent body | `followup_divergence` *(only path keeping the finding alive)* |
 | `TP_body_divergence` | TE attack body diverges from control body despite similar timing | `body_divergence_vs_control` |
+| `TP_second_request_status` | TE attack itself returns a clean fast 200; the *next* request is poisoned and returns 405 | `second_request_desync` |
+| `TP_second_request_body` | TE attack returns a clean 200; the poisoned follow-up keeps 200 but returns a truncated body | `second_request_desync` |
+| `TP_second_request_persistent` | TE attack poisons the upstream connection persistently; every follow-up diverges (3/3) | `second_request_desync` |
 
 The follow-up and body-divergence scenarios are constructed so that *only*
 the named signal can rescue the finding from the standard FP rejection rules
 — this verifies the intended detection pathway in isolation.
+
+### Second-request (stateful) desync
+
+The three `TP_second_request_*` scenarios model the classic "second-request"
+CL.TE signature: the smuggling request itself elicits a perfectly normal, fast
+`200` response (no timing or status anomaly at all), and the desync only
+surfaces on the **following** request that reuses the poisoned proxy↔backend
+connection. These are *stateful* — a TE-carrying request plants a poison flag
+and the next request consumes it — so they faithfully reproduce shared-upstream
+corruption rather than a per-request status/timing pattern.
+
+Detecting them requires smugglex's unconditional **second-request probe**: when
+the main payload loop finds no direct anomaly, it plants a TE payload and sends
+fresh follow-up GETs, looking for structural (non-5xx status or body)
+divergence from the baseline that **reproduces across two independent
+plant+probe sequences**. This is the same pathway that detects the real
+socket-level desync in [`desync/`](desync/README.md), whose CL.TE attack also
+returns a benign `200` and only corrupts the next request on the shared backend
+connection.
 
 ## Adding a scenario
 

--- a/lab/desync/README.md
+++ b/lab/desync/README.md
@@ -70,11 +70,21 @@ cargo build --release
 ./target/release/smugglex http://127.0.0.1:8081/
 ```
 
-Expected (vulnerable `:8080`): the CL.TE check fires at **high** confidence with
-signals such as `status_504`, a multi-second `timing_anomaly`, and
-`body_divergence_vs_control` — the ~6 s timing is the back-end genuinely hanging
-on a truncated chunk until the frontend's `UPSTREAM_TIMEOUT` fires (504). The
-smuggle exploit prints `CL.TE [TE:plain]: [200, 405, 405, …]` and
+Expected (vulnerable `:8080`): the scan reports the chain as vulnerable (exit
+code `1`) via two complementary pathways:
+
+- The **`cl-te`** check fires through the **second-request probe**
+  (`second_request_desync`, `followup_divergence`, medium confidence). The
+  CL.TE attack body (`0\r\n\r\nG`) carries a *complete* chunk, so the attack
+  request itself gets a clean, fast `200` — no timing or status anomaly. The
+  surplus `G` poisons the shared backend connection, so the *next* request is
+  reframed (`GGET …` → backend `405`), which the probe observes as follow-up
+  divergence from the baseline.
+- The **`te-cl`** check fires through `status_504` and a multi-second
+  `timing_anomaly`: its incomplete-chunk payloads leave the TE backend blocked
+  reading a truncated chunk until the frontend's `UPSTREAM_TIMEOUT` fires (504).
+
+The smuggle exploit prints `CL.TE [TE:plain]: [200, 405, 405, …]` and
 `Smuggle delivered`.
 
 Expected (patched `:8081`): **no** checks vulnerable, no smuggle delivered.

--- a/lab/validate.cr
+++ b/lab/validate.cr
@@ -60,6 +60,52 @@ def has_nonzero_content_length?(req : Bytes) : Bool
   false
 end
 
+# Shared state for the stateful second-request ("second request") desync
+# scenarios. A genuine CL.TE desync poisons a *shared* upstream connection, so
+# the corruption manifests on the request that FOLLOWS the smuggling request
+# rather than on the smuggling request itself. We model that with a single
+# boolean: a TE-carrying request plants the poison (and itself gets a clean
+# 200); the next non-TE request consumes it and is reinterpreted by the
+# "backend". Reset between scenarios by the harness.
+class DesyncState
+  @@poisoned = false
+
+  def self.reset
+    @@poisoned = false
+  end
+
+  def self.plant!
+    @@poisoned = true
+  end
+
+  def self.poisoned? : Bool
+    @@poisoned
+  end
+
+  # Returns whether a poison was pending and clears it (consumed by one request).
+  def self.consume! : Bool
+    was = @@poisoned
+    @@poisoned = false
+    was
+  end
+end
+
+# One-shot GET counter for the transient-blip FP scenario. The harness sends a
+# fixed GET prologue (the timing baseline) before any follow-up probe, so a
+# deterministic GET index lets a scenario inject a single non-recurring blip.
+class GetCounter
+  @@count = 0
+
+  def self.reset
+    @@count = 0
+  end
+
+  def self.next : Int32
+    @@count += 1
+    @@count
+  end
+end
+
 # --------------------------- scenario implementations -----------------------
 
 # Always returns a normal fast response — nothing suspicious anywhere.
@@ -167,7 +213,101 @@ def tp_body_divergence(sock : TCPSocket, req : Bytes, n : Int32)
   end
 end
 
+# ---- Second-request (stateful) desync true positives ----
+
+# Classic second-request CL.TE: the smuggling (TE-carrying) request itself gets
+# a clean, fast 200 — NO timing/status anomaly on the attack response at all —
+# but it poisons the shared upstream connection so the FOLLOWING request is
+# reinterpreted by the backend and returns 405. The attack response carries no
+# direct signal, so the only detection pathway is the unconditional
+# second-request probe (plant + follow-up divergence). Before that probe
+# existed, smugglex missed this entirely.
+def tp_second_request_status(sock : TCPSocket, req : Bytes, n : Int32)
+  if has_transfer_encoding?(req)
+    DesyncState.plant!
+    sock.write(http_response(NORMAL_BODY)) # clean 200, fast — no anomaly
+  elsif DesyncState.consume!
+    sock.write(http_response("Method Not Allowed", status: "405 Method Not Allowed"))
+  else
+    sock.write(http_response(NORMAL_BODY))
+  end
+end
+
+# Second-request desync where the poisoned follow-up keeps the 200 status but
+# returns a structurally smaller body (the smuggled prefix truncated the
+# response). Exercises the body-divergence branch of the second-request probe
+# rather than the status-divergence branch.
+def tp_second_request_body(sock : TCPSocket, req : Bytes, n : Int32)
+  if has_transfer_encoding?(req)
+    DesyncState.plant!
+    sock.write(http_response(NORMAL_BODY))
+  elsif DesyncState.consume!
+    sock.write(http_response(SMALL_ERROR_BODY)) # 200 but tiny body → diverges
+  else
+    sock.write(http_response(NORMAL_BODY))
+  end
+end
+
+# Persistent desync: once the TE smuggling request poisons the shared upstream
+# connection it stays corrupted, so EVERY follow-up GET diverges (3/3) — the
+# backend is left mid-parse and never recovers until the connection is recycled.
+# Distinct from the single-shot 405 case (which consumes the poison after one
+# request) and exercises the probe's full-divergence path.
+def tp_second_request_persistent(sock : TCPSocket, req : Bytes, n : Int32)
+  if has_transfer_encoding?(req)
+    DesyncState.plant!
+    sock.write(http_response(NORMAL_BODY))
+  elsif DesyncState.poisoned? # stays poisoned — does not consume
+    sock.write(http_response("Bad Request", status: "400 Bad Request"))
+  else
+    sock.write(http_response(NORMAL_BODY))
+  end
+end
+
 # ---- Additional realistic FP scenarios ----
+
+# A single, one-off 404 blip on the first post-baseline follow-up GET that does
+# NOT recur. The second-request probe requires follow-up divergence to reproduce
+# across TWO independent plant+probe sequences, so a non-recurring transient must
+# be rejected. The harness sends 3 GET baseline probes first, so GET #4 is the
+# first follow-up of the probe's first sequence; the second sequence (GETs #7-9)
+# sees only clean 200s and breaks reproduction.
+def fp_transient_404(sock : TCPSocket, req : Bytes, n : Int32)
+  if request_starts_with?(req, "GET") && GetCounter.next == 4
+    sock.write(http_response("Not Found", status: "404 Not Found"))
+    return
+  end
+  sock.write(http_response(NORMAL_BODY))
+end
+
+# An upstream that is healthy for the baseline window but then becomes
+# overloaded and returns 503 (Service Unavailable, a 5xx) to every subsequent
+# request — including the second-request probe's follow-up GETs. 5xx follow-up
+# responses must be IGNORED by the second-request probe (gateway/server errors
+# are flake-prone and handled by the timing/status confirmation path), so even
+# though the 503 body differs sharply from the baseline body this must NOT flag.
+def fp_followup_503_overload(sock : TCPSocket, req : Bytes, n : Int32)
+  if n <= 3
+    sock.write(http_response(NORMAL_BODY)) # baseline window → healthy 200
+  else
+    sock.write(http_response("Service Unavailable", status: "503 Service Unavailable"))
+  end
+end
+
+# A backend that returns 405 to any request carrying a body (TE or non-zero CL)
+# — e.g. an endpoint that only accepts bodyless GET/HEAD — while plain follow-up
+# GETs return the normal 200. The smuggling (TE) request gets a 405, but that is
+# the attack response itself, not a poisoned follow-up: the follow-up GETs are
+# clean. A naive detector keying on "TE request returns a different status" would
+# flag; the second-request probe (which only inspects follow-ups) must not.
+def fp_te_request_405(sock : TCPSocket, req : Bytes, n : Int32)
+  body_present = has_transfer_encoding?(req) || has_nonzero_content_length?(req)
+  if body_present
+    sock.write(http_response("Method Not Allowed", status: "405 Method Not Allowed"))
+  else
+    sock.write(http_response(NORMAL_BODY))
+  end
+end
 
 # A WAF in front of a healthy backend rejects any request carrying
 # Transfer-Encoding with a small 403 body. Non-TE shapes pass through to
@@ -284,6 +424,24 @@ SCENARIOS = [
     expected_vulnerable: false,
     notes: "~5% transient 504s; strict-majority confirmation must suppress",
   ),
+  Scenario.new(
+    "FP_followup_503_overload",
+    ->fp_followup_503_overload(TCPSocket, Bytes, Int32),
+    expected_vulnerable: false,
+    notes: "post-baseline 503s; 5xx follow-ups must be ignored by second-request probe",
+  ),
+  Scenario.new(
+    "FP_te_request_405",
+    ->fp_te_request_405(TCPSocket, Bytes, Int32),
+    expected_vulnerable: false,
+    notes: "TE/body requests get 405 but follow-up GETs are clean — attack-response status diff is not desync",
+  ),
+  Scenario.new(
+    "FP_transient_404",
+    ->fp_transient_404(TCPSocket, Bytes, Int32),
+    expected_vulnerable: false,
+    notes: "one-off 404 on a single follow-up; second-request probe's reproduction requirement must reject",
+  ),
   # Positives (must flag)
   Scenario.new(
     "TP_clte_status",
@@ -312,6 +470,27 @@ SCENARIOS = [
     expected_vulnerable: true,
     required_signal_substrings: ["body_divergence_vs_control"],
     notes: "TE response body diverges from control body despite timing match",
+  ),
+  Scenario.new(
+    "TP_second_request_status",
+    ->tp_second_request_status(TCPSocket, Bytes, Int32),
+    expected_vulnerable: true,
+    required_signal_substrings: ["second_request_desync"],
+    notes: "attack response is a clean 200; only the poisoned follow-up (405) reveals the desync",
+  ),
+  Scenario.new(
+    "TP_second_request_body",
+    ->tp_second_request_body(TCPSocket, Bytes, Int32),
+    expected_vulnerable: true,
+    required_signal_substrings: ["second_request_desync"],
+    notes: "poisoned follow-up keeps 200 but returns a truncated body — body-divergence path of the probe",
+  ),
+  Scenario.new(
+    "TP_second_request_persistent",
+    ->tp_second_request_persistent(TCPSocket, Bytes, Int32),
+    expected_vulnerable: true,
+    required_signal_substrings: ["second_request_desync"],
+    notes: "persistent poison — every follow-up diverges (3/3) until the upstream connection recycles",
   ),
 ]
 
@@ -417,6 +596,10 @@ record Evaluation,
   summary : String
 
 def evaluate_scenario(sc : Scenario) : Evaluation
+  # Stateful scenarios share a single poison flag; clear it so each scenario
+  # starts from a clean upstream connection.
+  DesyncState.reset
+  GetCounter.reset
   server = TCPServer.new("127.0.0.1", 0)
   port = server.local_address.port
   spawn serve_forever(server, sc.handler)

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -546,6 +546,11 @@ struct FollowupObservation {
     diverging: usize,
     /// Total number of follow-up probes actually sent (failures excluded).
     total: usize,
+    /// True when this observation came from the unconditional second-request
+    /// desync probe (i.e., the attack itself carried no direct anomaly and the
+    /// finding rests entirely on follow-up corruption). Used to emit the
+    /// `second_request_desync` signal.
+    second_request: bool,
 }
 
 impl FollowupObservation {
@@ -606,7 +611,116 @@ async fn observe_followup_divergence(
             }
         }
     }
-    FollowupObservation { diverging, total }
+    FollowupObservation {
+        diverging,
+        total,
+        second_request: false,
+    }
+}
+
+/// True when a follow-up probe status structurally diverges from the baseline:
+/// it differs from the baseline status AND is not a 5xx gateway/server error.
+/// 5xx responses (502/503/504) are flake-prone and already covered by the
+/// timing/status confirmation path, so excluding them keeps the unconditional
+/// second-request probe from firing on transient upstream errors.
+fn followup_status_diverged(status_code: Option<u16>, baseline_status: Option<u16>) -> bool {
+    match status_code {
+        Some(c) if c < 500 => status_code != baseline_status,
+        _ => false,
+    }
+}
+
+/// Send `FOLLOWUP_PROBE_COUNT` fresh-connection GET probes and count how many
+/// returned a response that *structurally* diverges from the baseline — a
+/// non-5xx status change (per `followup_status_diverged`) or a body-length
+/// divergence (per `bodies_diverge`). Stricter than `observe_followup_divergence`
+/// because it backs the unconditional second-request probe, where there is no
+/// prior anomaly to corroborate the finding.
+async fn count_structural_followup_divergence(
+    params: &PayloadCheckParams<'_>,
+    path: &str,
+    baseline: &BaselineMeasurement,
+) -> usize {
+    let probe = format!(
+        "GET {} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n",
+        path, params.host
+    );
+    let mut diverging = 0usize;
+    for _ in 0..FOLLOWUP_PROBE_COUNT {
+        if let Ok((response, _)) = send_request(
+            params.host,
+            params.port,
+            &probe,
+            params.timeout,
+            params.verbose,
+            params.use_tls,
+        )
+        .await
+        {
+            let status_line = response.lines().next().unwrap_or("");
+            let status_code = parse_status_code(status_line);
+            // Skip 5xx responses entirely — gateway/server errors are
+            // flake-prone (overload, transient upstream failures) and are
+            // handled by the timing/status confirmation path, not the
+            // second-request probe. This also prevents a small 5xx error-page
+            // body from tripping the body-divergence check below.
+            if matches!(status_code, Some(c) if c >= 500) {
+                continue;
+            }
+            let body_len = response_body_length(&response);
+            if followup_status_diverged(status_code, baseline.status_code)
+                || bodies_diverge(body_len, baseline.body_length)
+            {
+                diverging += 1;
+            }
+        }
+    }
+    diverging
+}
+
+/// Unconditional second-request desync probe, run only when the main payload
+/// loop found no direct anomaly. Some CL.TE desyncs return a perfectly normal
+/// response to the smuggling request itself and only corrupt the *following*
+/// request on the shared proxy↔backend connection (the classic "second-request"
+/// smuggling signature). We plant the first TE-carrying payload, then send
+/// fresh follow-up GETs and look for structural divergence from the baseline.
+///
+/// To suppress transient backend flakiness the divergence must reproduce across
+/// two independent plant+probe sequences — a single corrupted follow-up is not
+/// enough. Returns a `FollowupObservation` (with `second_request = true`) only
+/// when both sequences observed divergence.
+async fn probe_second_request_desync(
+    params: &PayloadCheckParams<'_>,
+    path: &str,
+    baseline: &BaselineMeasurement,
+) -> Option<FollowupObservation> {
+    const PLANT_PROBE_SEQUENCES: usize = 2;
+    let mut diverging_min = usize::MAX;
+    for _ in 0..PLANT_PROBE_SEQUENCES {
+        // Plant: send the smuggling payload to corrupt the shared upstream
+        // connection. Its own response is irrelevant here — the main loop has
+        // already established it carries no direct anomaly.
+        let _ = send_request(
+            params.host,
+            params.port,
+            params.attack_request,
+            params.timeout,
+            params.verbose,
+            params.use_tls,
+        )
+        .await;
+        let d = count_structural_followup_divergence(params, path, baseline).await;
+        if d == 0 {
+            // Not reproduced → transient backend behavior, not a desync.
+            return None;
+        }
+        diverging_min = diverging_min.min(d);
+    }
+    Some(FollowupObservation {
+        diverging: diverging_min,
+        total: FOLLOWUP_PROBE_COUNT,
+        second_request: true,
+    })
 }
 
 /// True if attack and control responses have structurally different bodies
@@ -824,10 +938,13 @@ fn collect_detection_signals(
             signals.push(format!("header_divergence_vs_control:{}", header_diff));
         }
     }
-    if let Some(f) = followup
-        && f.has_divergence()
-    {
-        signals.push(format!("followup_divergence:{}/{}", f.diverging, f.total));
+    if let Some(f) = followup {
+        if f.has_divergence() {
+            signals.push(format!("followup_divergence:{}/{}", f.diverging, f.total));
+        }
+        if f.second_request {
+            signals.push("second_request_desync".to_string());
+        }
     }
     signals
 }
@@ -1110,6 +1227,55 @@ pub async fn run_checks_for_type(params: CheckParams<'_>) -> Result<CheckResult>
                     );
                 }
             }
+        }
+    }
+
+    // Second-request desync probe: only when the main loop found no direct
+    // anomaly and did not early-terminate. Catches CL.TE desyncs whose attack
+    // response is itself benign and only the FOLLOWING request on the shared
+    // upstream connection is corrupted.
+    if vulnerability_info.is_none()
+        && early_termination.is_none()
+        && let Some((idx, plant_payload)) = params
+            .attack_requests
+            .iter()
+            .enumerate()
+            .find(|(_, p)| payload_eligible_for_control(p))
+    {
+        let payload_params = PayloadCheckParams {
+            host: params.host,
+            port: params.port,
+            attack_request: plant_payload,
+            timeout: params.timeout,
+            verbose: params.verbose,
+            use_tls: params.use_tls,
+            timing_threshold,
+            baseline_status_codes: &baseline.observed_status_codes,
+        };
+        if let Some(followup) =
+            probe_second_request_desync(&payload_params, params.path, &baseline).await
+        {
+            if params.verbose {
+                println!(
+                    "  {} {} second-request desync detected: {}/{} follow-up probes diverged from baseline",
+                    "[+]".green(),
+                    params.check_name,
+                    followup.diverging,
+                    followup.total,
+                );
+            }
+            // The attack request itself carried no anomaly — synthesize a
+            // benign VulnerabilityInfo so the finding is reported as a
+            // medium-confidence second-request desync.
+            let info = VulnerabilityInfo {
+                status: normal_status.clone(),
+                status_code: baseline.status_code,
+                duration: normal_duration,
+                body_length: baseline.body_length,
+                header_fingerprint: ResponseHeaderFingerprint::default(),
+                is_connection_timeout: false,
+            };
+            vulnerability_info = Some((idx, plant_payload.clone(), info, None, Some(followup)));
         }
     }
 
@@ -1540,6 +1706,7 @@ mod tests {
         let followup = FollowupObservation {
             diverging: 2,
             total: 3,
+            second_request: false,
         };
         // Without follow-up: timing similarity would reject as FP. With
         // follow-up divergence: escape clause keeps the finding.
@@ -1570,6 +1737,7 @@ mod tests {
         let followup = FollowupObservation {
             diverging: 0,
             total: 3,
+            second_request: false,
         };
         // No follow-up divergence + similar timing → standard FP rule fires.
         assert!(control_indicates_false_positive(
@@ -1580,15 +1748,72 @@ mod tests {
     }
 
     #[test]
+    fn followup_status_diverged_flags_non_5xx_change() {
+        // A 4xx/3xx follow-up where the baseline was 200 is a structural divergence.
+        assert!(followup_status_diverged(Some(405), Some(200)));
+        assert!(followup_status_diverged(Some(400), Some(200)));
+        assert!(followup_status_diverged(Some(301), Some(200)));
+    }
+
+    #[test]
+    fn followup_status_diverged_ignores_5xx() {
+        // 5xx responses are flake-prone and must NOT drive the second-request
+        // probe, even when they differ from the baseline.
+        assert!(!followup_status_diverged(Some(504), Some(200)));
+        assert!(!followup_status_diverged(Some(502), Some(200)));
+        assert!(!followup_status_diverged(Some(503), Some(200)));
+        assert!(!followup_status_diverged(None, Some(200)));
+    }
+
+    #[test]
+    fn followup_status_diverged_false_when_matching() {
+        assert!(!followup_status_diverged(Some(200), Some(200)));
+        assert!(!followup_status_diverged(Some(404), Some(404)));
+    }
+
+    #[test]
+    fn second_request_signal_emitted() {
+        let info = VulnerabilityInfo {
+            status: "HTTP/1.1 200 OK".into(),
+            status_code: Some(200),
+            duration: Duration::from_millis(5),
+            body_length: 500,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        let followup = FollowupObservation {
+            diverging: 1,
+            total: 3,
+            second_request: true,
+        };
+        let signals = collect_detection_signals(
+            &info,
+            Duration::from_millis(5),
+            100,
+            false,
+            None,
+            Some(&followup),
+        );
+        assert!(signals.iter().any(|s| s == "second_request_desync"));
+        assert!(
+            signals
+                .iter()
+                .any(|s| s.starts_with("followup_divergence:"))
+        );
+    }
+
+    #[test]
     fn followup_observation_reports_divergence() {
         let f = FollowupObservation {
             diverging: 1,
             total: 3,
+            second_request: false,
         };
         assert!(f.has_divergence());
         let none = FollowupObservation {
             diverging: 0,
             total: 3,
+            second_request: false,
         };
         assert!(!none.has_divergence());
     }


### PR DESCRIPTION
## Summary

Iterating on the Crystal smuggling lab revealed a real detection gap, which this PR closes while broadening lab coverage.

**The gap:** Some CL.TE desyncs return a perfectly clean, fast `200` to the smuggling request *itself* and only corrupt the **following** request on the shared proxy↔backend connection (the classic "second-request" signature). smugglex's follow-up divergence check only ran *after* an initial timing/`504` anomaly fired — so when the attack response looked normal, the desync was missed entirely. This included the repo's own real socket-level lab in `lab/desync/`: its `cl-te` attack body (`0\r\n\r\nG`) carries a *complete* chunk, so the attack gets a benign `200` and the surplus `G` poisons the next request — which the scanner never probed. Before this PR, scanning the vulnerable chain with `--checks cl-te` returned **0 findings (exit 0)**.

## What changed

### Detection — unconditional second-request probe (`src/scanner.rs`)
When the main payload loop finds no direct anomaly, smugglex now:
1. Plants a TE-carrying payload to corrupt the shared upstream connection.
2. Sends fresh follow-up `GET` probes and counts **structural** divergence from the baseline — a non-5xx status change or a body-length divergence.
3. Requires that divergence to **reproduce across two independent plant+probe sequences**.

FP safety is built in:
- **5xx follow-ups are ignored** (overload / transient upstream errors are flake-prone and already handled by the timing/status confirmation path).
- The **two-sequence reproduction requirement** rejects non-recurring transients; a clean target costs only ~4 extra requests per TE-check (early return after the first clean sequence).

Findings surface as a new `second_request_desync` detection signal at medium confidence.

### Lab — new scenarios (`lab/validate.cr`)
Added stateful "second-request" emulation (a TE request plants a poison flag consumed by the next request) plus guards:

| New true positives | New false positives |
|---|---|
| `TP_second_request_status` (poisoned follow-up → 405) | `FP_followup_503_overload` (5xx follow-ups ignored) |
| `TP_second_request_body` (poisoned follow-up → truncated body) | `FP_te_request_405` (attack-response status diff ≠ desync) |
| `TP_second_request_persistent` (every follow-up diverges, 3/3) | `FP_transient_404` (non-recurring blip must not reproduce) |

The TP scenarios fail without the new probe (the attack response carries no anomaly), so they exercise the fix in isolation.

## Verification

- `lab/validate.cr`: **18/18 scenarios pass** (was 12/12).
- Real desync lab (`lab/desync/`): vulnerable chain `cl-te` now detected (**exit 1**) with `second_request_desync` + `followup_divergence`; patched chain stays clean (**exit 0**).
- `cargo test` (all suites), `cargo clippy --all-targets -- -D warnings`, and `cargo fmt --check` all pass.

Docs updated: `lab/README.md`, `lab/desync/README.md`, and `CHANGELOG.md`.

https://claude.ai/code/session_01CK2uRq3FBJbXZbJVNrHE7Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01CK2uRq3FBJbXZbJVNrHE7Q)_