### PR TITLE
fix: harden parsing/detection stability and expand test coverage

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,42 @@ use std::fmt;
 /// (anything other than this default) before warning about a conflict.
 pub const DEFAULT_METHOD: &str = "POST";
 
+/// Every check name smugglex understands: the payload-string checks plus the
+/// real-HTTP/2 downgrade check. Used to validate `--checks` so a typo does not
+/// silently run zero checks and report a clean target.
+pub const KNOWN_CHECK_NAMES: [&str; 7] = [
+    "cl-te",
+    "te-cl",
+    "te-te",
+    "h2c",
+    "h2",
+    "cl-edge",
+    "h2-downgrade",
+];
+
+/// Return the names in a comma-separated `--checks` value that match no known
+/// check (trimmed; empty segments ignored). An empty result means every
+/// requested name was recognized.
+pub fn unknown_check_names(requested: &str, known: &[&str]) -> Vec<String> {
+    requested
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .filter(|s| !known.contains(s))
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Whether `requested` selects at least one known check. False means a typo'd
+/// `--checks` that would otherwise scan nothing.
+pub fn has_any_known_check(requested: &str, known: &[&str]) -> bool {
+    requested
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .any(|s| known.contains(&s))
+}
+
 /// Output format type
 #[derive(Debug, Clone, ValueEnum)]
 pub enum OutputFormat {
@@ -55,7 +91,7 @@ pub struct Cli {
     pub method: String,
 
     /// Socket timeout in seconds
-    #[arg(help_heading = "REQUEST", short, long, default_value_t = 10)]
+    #[arg(help_heading = "REQUEST", short, long, default_value_t = 10, value_parser = clap::value_parser!(u64).range(1..))]
     pub timeout: u64,
 
     /// Custom headers (format: "Header: Value")
@@ -240,5 +276,48 @@ impl Cli {
         } else {
             self.format.clone()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_check_names_flags_only_unrecognized() {
+        // A mix of valid and typo'd names returns just the unknown ones.
+        assert_eq!(
+            unknown_check_names("clte,cl-te,h2", &KNOWN_CHECK_NAMES),
+            vec!["clte".to_string()]
+        );
+        // All valid → empty.
+        assert!(unknown_check_names("cl-te, te-cl , h2-downgrade", &KNOWN_CHECK_NAMES).is_empty());
+        // Empty segments are ignored.
+        assert!(unknown_check_names("cl-te,,  ,h2", &KNOWN_CHECK_NAMES).is_empty());
+        // All invalid → every name reported.
+        assert_eq!(
+            unknown_check_names("clte,CL-TE,cl_te", &KNOWN_CHECK_NAMES),
+            vec!["clte".to_string(), "CL-TE".to_string(), "cl_te".to_string()]
+        );
+    }
+
+    #[test]
+    fn has_any_known_check_detects_all_typos() {
+        assert!(has_any_known_check("clte,cl-te", &KNOWN_CHECK_NAMES));
+        assert!(has_any_known_check("h2-downgrade", &KNOWN_CHECK_NAMES));
+        // A wholly typo'd selection must report no known check (the dangerous
+        // case: scanning nothing while reporting a clean target).
+        assert!(!has_any_known_check("clte", &KNOWN_CHECK_NAMES));
+        assert!(!has_any_known_check("CL-TE,cl_te", &KNOWN_CHECK_NAMES));
+        assert!(!has_any_known_check("  , ,", &KNOWN_CHECK_NAMES));
+    }
+
+    #[test]
+    fn timeout_zero_is_rejected_at_parse_time() {
+        // `-t 0` makes every request elapse instantly; clap must reject it.
+        assert!(Cli::try_parse_from(["smugglex", "http://x", "-t", "0"]).is_err());
+        // A positive timeout still parses.
+        let cli = Cli::try_parse_from(["smugglex", "http://x", "-t", "5"]).unwrap();
+        assert_eq!(cli.timeout, 5);
     }
 }

--- a/src/exploit/capture.rs
+++ b/src/exploit/capture.rs
@@ -51,7 +51,13 @@ fn diverges_from_baseline(resp: &str, base_status: &str, base_body_len: usize) -
     if resp.trim().is_empty() {
         return false;
     }
-    if status_line(resp) != base_status {
+    // When the baseline GET failed (empty base_status) we cannot judge
+    // divergence: skipping this guard would make *every* non-empty follow-up
+    // compare unequal to "" and be reported as a captured smuggled response,
+    // fabricating a capture on a flaky/unreachable target. The body-size branch
+    // below is already gated by `base_body_len > 0`, so an unavailable baseline
+    // now yields no false capture.
+    if !base_status.is_empty() && status_line(resp) != base_status {
         return true;
     }
     let bl = body(resp).len() as i64;
@@ -81,6 +87,13 @@ pub async fn test_capture(params: &CaptureParams<'_>) -> Result<CaptureResult> {
 
     let inner = params.smuggled_request.trim_end();
     let mut observations = Vec::new();
+    if base_status.is_empty() {
+        observations.push(
+            "baseline GET unavailable (empty/failed response); divergence cannot be judged, \
+             so no capture will be reported"
+                .to_string(),
+        );
+    }
 
     for (vlabel, te) in TE_VARIANTS {
         for (shape, wrapper) in [
@@ -192,5 +205,21 @@ mod tests {
         assert!(diverges_from_baseline(&big, "HTTP/1.1 200 OK", 500));
         // empty response -> not a capture
         assert!(!diverges_from_baseline("", "HTTP/1.1 200 OK", 500));
+    }
+
+    #[test]
+    fn empty_baseline_is_not_a_capture() {
+        // A failed baseline (empty base_status, base_body_len 0) must never make
+        // a non-empty follow-up look like a captured smuggled response.
+        assert!(!diverges_from_baseline(
+            "HTTP/1.1 200 OK\r\n\r\nbody",
+            "",
+            0
+        ));
+        assert!(!diverges_from_baseline(
+            "HTTP/1.1 500 Internal Server Error\r\n\r\nerror page",
+            "",
+            0
+        ));
     }
 }

--- a/src/exploit/localhost_access.rs
+++ b/src/exploit/localhost_access.rs
@@ -504,4 +504,15 @@ mod tests {
         let (head, body) = payload.split_once("\r\n\r\n").unwrap();
         assert_eq!(content_length(head), body.len());
     }
+
+    #[test]
+    fn tecl_localhost_payload_backend_cl_consumes_only_first_chunk_line() {
+        // TE.CL: the back-end Content-Length must consume exactly "1\r\nX\r\n"
+        // (6 bytes), leaving the smuggled localhost request as the next request.
+        let payload = generate_tecl_localhost_payload("/", "example.com", 8080);
+        let (head, body) = payload.split_once("\r\n\r\n").unwrap();
+        let cl = content_length(head);
+        assert_eq!(&body.as_bytes()[..cl], b"1\r\nX\r\n");
+        assert!(body[cl..].starts_with("0\r\n\r\nGET / HTTP/1.1"));
+    }
 }

--- a/src/exploit/path_fuzz.rs
+++ b/src/exploit/path_fuzz.rs
@@ -592,4 +592,17 @@ mod tests {
         let (head, body) = payload.split_once("\r\n\r\n").unwrap();
         assert_eq!(content_length(head), body.len());
     }
+
+    #[test]
+    fn tecl_path_fuzz_payload_backend_cl_consumes_only_first_chunk_line() {
+        // TE.CL: the back-end Content-Length must consume exactly the first
+        // chunk-size line + data + CRLF ("1\r\nX\r\n" = 6 bytes), leaving the
+        // smuggled request (`0\r\n\r\nGET ...`) as the next request. An off-by-one
+        // here would mis-frame or stall the smuggle.
+        let payload = generate_tecl_path_fuzz_payload("/admin", "example.com");
+        let (head, body) = payload.split_once("\r\n\r\n").unwrap();
+        let cl = content_length(head);
+        assert_eq!(&body.as_bytes()[..cl], b"1\r\nX\r\n");
+        assert!(body[cl..].starts_with("0\r\n\r\nGET /admin"));
+    }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -278,7 +278,13 @@ async fn read_one_http_response<S: AsyncRead + Unpin + ?Sized>(stream: &mut S) -
         if let Some(he) = header_end {
             match framing {
                 BodyFraming::ContentLength(len) => {
-                    if buf.len() >= he + len {
+                    // Checked addition so a hostile/garbled response advertising a
+                    // near-`usize::MAX` Content-Length cannot overflow `he + len`
+                    // (a debug-build panic, or a release-build wrap that would make
+                    // the comparison true and return a truncated response). An
+                    // unsatisfiable total simply means "keep reading until EOF",
+                    // which is the safe behavior. Mirrors `response_complete_len`.
+                    if he.checked_add(len).is_some_and(|total| buf.len() >= total) {
                         break;
                     }
                 }
@@ -322,9 +328,15 @@ pub async fn pipeline_requests(
     use_tls: bool,
 ) -> Result<Vec<String>> {
     let timeout_dur = Duration::from_secs(timeout);
-    let bytes = tokio::time::timeout(timeout_dur, async {
+    // `responses` is owned *outside* the timeout scope so that an elapsed
+    // timeout preserves whatever was collected so far — the documented
+    // contract, and what response-queue capture relies on: a smuggled
+    // request's response is delivered to a *later* request, and the exchange
+    // routinely stalls on a hanging follow-up precisely when an interesting
+    // response is already buffered. Dropping it would be a false negative.
+    let mut responses: Vec<Vec<u8>> = Vec::with_capacity(requests.len());
+    let outcome = tokio::time::timeout(timeout_dur, async {
         let mut stream = get_stream(host, port, use_tls).await?;
-        let mut responses: Vec<Vec<u8>> = Vec::with_capacity(requests.len());
         // Bytes already read that belong to a later response (the response-queue
         // offset that capture relies on) are carried between reads.
         let mut carry: Vec<u8> = Vec::new();
@@ -339,12 +351,24 @@ pub async fn pipeline_requests(
                 None => break, // peer closed with nothing left to read
             }
         }
-        Ok::<Vec<Vec<u8>>, crate::error::SmugglexError>(responses)
+        Ok::<(), crate::error::SmugglexError>(())
     })
-    .await
-    .unwrap_or_else(|_| Ok(Vec::new()))?;
+    .await;
 
-    Ok(bytes
+    match outcome {
+        // Completed within the timeout, or timed out: either way return what we
+        // collected. A mid-exchange connection error only surfaces when nothing
+        // was captured — once we hold at least one response it is more useful
+        // (and matches the timeout contract) to return it than to discard it.
+        Ok(Ok(())) | Err(_) => {}
+        Ok(Err(e)) => {
+            if responses.is_empty() {
+                return Err(e);
+            }
+        }
+    }
+
+    Ok(responses
         .into_iter()
         .map(|b| match String::from_utf8(b) {
             Ok(s) => s,
@@ -476,5 +500,70 @@ mod tests {
         // overflow/panic; it just reads as incomplete.
         let huge = format!("{:x}\r\nAB", usize::MAX);
         assert!(!chunked_body_complete(huge.as_bytes()));
+    }
+
+    #[test]
+    fn response_complete_len_content_length() {
+        let buf = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nAB";
+        assert_eq!(response_complete_len(buf), Some(buf.len()));
+        // One byte short of the declared body -> not yet complete.
+        let short = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nA";
+        assert_eq!(response_complete_len(short), None);
+    }
+
+    #[test]
+    fn response_complete_len_chunked_with_trailers() {
+        let buf = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\nX-T: 1\r\n\r\n";
+        assert_eq!(response_complete_len(buf), Some(buf.len()));
+    }
+
+    #[test]
+    fn response_complete_len_oversized_content_length_does_not_panic() {
+        // A hostile/garbled `Content-Length: <usize::MAX>` must not overflow the
+        // `header_end + n` computation; the response simply reads as incomplete.
+        let raw = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\nAB",
+            usize::MAX
+        );
+        assert_eq!(response_complete_len(raw.as_bytes()), None);
+    }
+
+    #[tokio::test]
+    async fn read_one_http_response_oversized_content_length_does_not_panic() {
+        // Regression for the unchecked `he + len` overflow: under debug
+        // overflow-checks this previously panicked; it must instead read to EOF
+        // and return what arrived.
+        let raw = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\nAB",
+            usize::MAX
+        );
+        let data = raw.into_bytes();
+        let mut slice: &[u8] = &data;
+        let out = read_one_http_response(&mut slice).await.unwrap();
+        assert!(out.starts_with(b"HTTP/1.1 200 OK"));
+    }
+
+    #[tokio::test]
+    async fn read_one_framed_splits_two_glued_responses_and_carries_surplus() {
+        // Two complete Content-Length responses arrive glued in one buffer. The
+        // first call must return response A and carry B for the next read; the
+        // second call returns B from the carry; the third hits EOF.
+        let a = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nAB";
+        let b = b"HTTP/1.1 404 NF\r\nContent-Length: 2\r\n\r\nCD";
+        let mut data = Vec::new();
+        data.extend_from_slice(a);
+        data.extend_from_slice(b);
+        let mut slice: &[u8] = &data;
+        let mut carry: Vec<u8> = Vec::new();
+
+        let first = read_one_framed(&mut slice, &mut carry).await.unwrap();
+        assert_eq!(first.as_deref(), Some(&a[..]));
+        assert_eq!(carry, b.to_vec(), "surplus bytes for B must be carried");
+
+        let second = read_one_framed(&mut slice, &mut carry).await.unwrap();
+        assert_eq!(second.as_deref(), Some(&b[..]));
+
+        let third = read_one_framed(&mut slice, &mut carry).await.unwrap();
+        assert_eq!(third, None, "EOF with empty carry yields None");
     }
 }

--- a/src/http2.rs
+++ b/src/http2.rs
@@ -143,6 +143,14 @@ impl H2Request<'_> {
 
 fn put_frame(out: &mut Vec<u8>, ftype: u8, flags: u8, stream: u32, payload: &[u8]) {
     let len = payload.len();
+    // The frame length field is 24 bits. All payloads smugglex emits are tiny
+    // (a small HPACK header block or a few-byte DATA body), so exceeding this
+    // would be a bug — guard it rather than silently truncating into a corrupt
+    // frame that desyncs the whole outbound stream.
+    debug_assert!(
+        len <= 0xFF_FFFF,
+        "HTTP/2 frame payload ({len} bytes) exceeds the 24-bit length field"
+    );
     out.push((len >> 16) as u8);
     out.push((len >> 8) as u8);
     out.push(len as u8);
@@ -247,6 +255,82 @@ async fn h2_probe(
     }
 }
 
+/// A single declared frame larger than this is treated as a hostile/garbled
+/// peer and rejected, instead of letting the accumulation buffer grow toward
+/// the 16 MiB the 24-bit length field allows. A real response HEADERS frame is
+/// tiny; 1 MiB is a generous ceiling.
+const MAX_FRAME_BYTES: usize = 1 << 20;
+
+/// Outcome of scanning the accumulation buffer for a decisive frame.
+enum FrameScan {
+    /// A terminal frame (response HEADERS / RST / GOAWAY, or an oversized frame)
+    /// decided the outcome. `send_settings_ack` is true if a non-ACK server
+    /// SETTINGS frame was seen first and still needs acknowledging.
+    Outcome {
+        outcome: H2Outcome,
+        send_settings_ack: bool,
+    },
+    /// No terminal frame yet; `consumed` leading bytes were fully parsed and can
+    /// be drained. `send_settings_ack` flags an owed SETTINGS ACK.
+    NeedMore {
+        consumed: usize,
+        send_settings_ack: bool,
+    },
+}
+
+/// Pure frame-boundary scan over the accumulation buffer. Reads the 24-bit
+/// length, type, flags and stream id of each fully-buffered frame and decides
+/// the probe outcome. Bounds are fully checked (`acc.len() >= i + 9` before
+/// reading a header, `acc.len() >= i + 9 + flen` before slicing the payload),
+/// so a hostile length field can never index out of bounds; an oversized
+/// declared length is rejected via [`MAX_FRAME_BYTES`].
+fn scan_frames(acc: &[u8]) -> FrameScan {
+    let terminal = |responded: bool, status: Option<u16>, reset: bool| H2Outcome {
+        responded,
+        status,
+        reset,
+        duration: Duration::ZERO,
+    };
+    let mut i = 0;
+    let mut send_settings_ack = false;
+    while acc.len() >= i + 9 {
+        let flen = ((acc[i] as usize) << 16) | ((acc[i + 1] as usize) << 8) | acc[i + 2] as usize;
+        let ftype = acc[i + 3];
+        let flags = acc[i + 4];
+        let stream_id = u32::from_be_bytes([acc[i + 5] & 0x7f, acc[i + 6], acc[i + 7], acc[i + 8]]);
+        if flen > MAX_FRAME_BYTES {
+            return FrameScan::Outcome {
+                outcome: terminal(false, None, true),
+                send_settings_ack,
+            };
+        }
+        if acc.len() < i + 9 + flen {
+            break; // frame body not fully received yet
+        }
+        let payload = &acc[i + 9..i + 9 + flen];
+
+        if ftype == FRAME_SETTINGS && flags & FLAG_ACK == 0 {
+            send_settings_ack = true;
+        } else if ftype == FRAME_HEADERS && stream_id == 1 {
+            let status = payload.first().copied().and_then(status_from_indexed);
+            return FrameScan::Outcome {
+                outcome: terminal(true, status, false),
+                send_settings_ack,
+            };
+        } else if (ftype == FRAME_RST_STREAM && stream_id == 1) || ftype == FRAME_GOAWAY {
+            return FrameScan::Outcome {
+                outcome: terminal(false, None, true),
+                send_settings_ack,
+            };
+        }
+        i += 9 + flen;
+    }
+    FrameScan::NeedMore {
+        consumed: i,
+        send_settings_ack,
+    }
+}
+
 /// Read frames until a response HEADERS for our stream arrives, or the peer
 /// resets/closes. ACKs the server SETTINGS so the connection stays live.
 async fn read_response<S: AsyncRead + AsyncWrite + Unpin>(stream: &mut S) -> Result<H2Outcome> {
@@ -264,42 +348,30 @@ async fn read_response<S: AsyncRead + AsyncWrite + Unpin>(stream: &mut S) -> Res
         }
         acc.extend_from_slice(&buf[..n]);
 
-        let mut i = 0;
-        while acc.len() >= i + 9 {
-            let flen =
-                ((acc[i] as usize) << 16) | ((acc[i + 1] as usize) << 8) | acc[i + 2] as usize;
-            let ftype = acc[i + 3];
-            let flags = acc[i + 4];
-            let stream_id =
-                u32::from_be_bytes([acc[i + 5] & 0x7f, acc[i + 6], acc[i + 7], acc[i + 8]]);
-            if acc.len() < i + 9 + flen {
-                break; // frame body not fully received yet
+        match scan_frames(&acc) {
+            FrameScan::Outcome {
+                outcome,
+                send_settings_ack,
+            } => {
+                if send_settings_ack {
+                    let mut ack = Vec::new();
+                    put_frame(&mut ack, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+                    stream.write_all(&ack).await?;
+                }
+                return Ok(outcome);
             }
-            let payload = &acc[i + 9..i + 9 + flen];
-
-            if ftype == FRAME_SETTINGS && flags & FLAG_ACK == 0 {
-                let mut ack = Vec::new();
-                put_frame(&mut ack, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
-                stream.write_all(&ack).await?;
-            } else if ftype == FRAME_HEADERS && stream_id == 1 {
-                let status = payload.first().copied().and_then(status_from_indexed);
-                return Ok(H2Outcome {
-                    responded: true,
-                    status,
-                    reset: false,
-                    duration: Duration::ZERO,
-                });
-            } else if (ftype == FRAME_RST_STREAM && stream_id == 1) || ftype == FRAME_GOAWAY {
-                return Ok(H2Outcome {
-                    responded: false,
-                    status: None,
-                    reset: true,
-                    duration: Duration::ZERO,
-                });
+            FrameScan::NeedMore {
+                consumed,
+                send_settings_ack,
+            } => {
+                if send_settings_ack {
+                    let mut ack = Vec::new();
+                    put_frame(&mut ack, FRAME_SETTINGS, FLAG_ACK, 0, &[]);
+                    stream.write_all(&ack).await?;
+                }
+                acc.drain(0..consumed);
             }
-            i += 9 + flen;
         }
-        acc.drain(0..i);
     }
 }
 
@@ -596,5 +668,109 @@ mod tests {
             duration: Duration::from_millis(200),
         };
         assert!(!stalled(&ok, to));
+    }
+
+    #[test]
+    fn scan_frames_decodes_headers_status() {
+        let mut acc = Vec::new();
+        put_frame(&mut acc, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]); // :status 200
+        match scan_frames(&acc) {
+            FrameScan::Outcome { outcome, .. } => {
+                assert!(outcome.responded);
+                assert_eq!(outcome.status, Some(200));
+            }
+            _ => panic!("expected a terminal HEADERS outcome"),
+        }
+    }
+
+    #[test]
+    fn scan_frames_acks_settings_before_headers() {
+        let mut acc = Vec::new();
+        put_frame(&mut acc, FRAME_SETTINGS, 0, 0, &[]); // server SETTINGS (needs ACK)
+        put_frame(&mut acc, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+        match scan_frames(&acc) {
+            FrameScan::Outcome {
+                outcome,
+                send_settings_ack,
+            } => {
+                assert!(outcome.responded);
+                assert!(send_settings_ack, "non-ACK SETTINGS must be acknowledged");
+            }
+            _ => panic!("expected a terminal outcome"),
+        }
+    }
+
+    #[test]
+    fn scan_frames_maps_rst_and_goaway_to_reset() {
+        let mut rst = Vec::new();
+        put_frame(&mut rst, FRAME_RST_STREAM, 0, 1, &[0, 0, 0, 0]);
+        match scan_frames(&rst) {
+            FrameScan::Outcome { outcome, .. } => assert!(outcome.reset && !outcome.responded),
+            _ => panic!("RST_STREAM(1) should be terminal"),
+        }
+        let mut goaway = Vec::new();
+        put_frame(&mut goaway, FRAME_GOAWAY, 0, 0, &[0, 0, 0, 0, 0, 0, 0, 0]);
+        match scan_frames(&goaway) {
+            FrameScan::Outcome { outcome, .. } => assert!(outcome.reset),
+            _ => panic!("GOAWAY should be terminal"),
+        }
+    }
+
+    #[test]
+    fn scan_frames_needs_more_on_partial_frame() {
+        // A 9-byte header declaring a 10-byte payload with no body yet.
+        let acc = vec![0, 0, 10, FRAME_HEADERS, FLAG_END_HEADERS, 0, 0, 0, 1];
+        match scan_frames(&acc) {
+            FrameScan::NeedMore { consumed, .. } => assert_eq!(consumed, 0),
+            _ => panic!("a partial frame should request more bytes"),
+        }
+    }
+
+    #[test]
+    fn scan_frames_rejects_oversized_frame_without_buffering() {
+        // 0xFFFFFF (16 MiB) exceeds MAX_FRAME_BYTES: reject fast, never slice.
+        let acc = vec![0xFF, 0xFF, 0xFF, FRAME_HEADERS, 0, 0, 0, 0, 1];
+        match scan_frames(&acc) {
+            FrameScan::Outcome { outcome, .. } => assert!(outcome.reset),
+            _ => panic!("an oversized declared frame must be rejected"),
+        }
+    }
+
+    #[test]
+    fn scan_frames_drains_settings_then_awaits_partial_headers() {
+        let mut acc = Vec::new();
+        put_frame(&mut acc, FRAME_SETTINGS, 0, 0, &[]); // 9 bytes, fully present
+        acc.extend_from_slice(&[0, 0, 10, FRAME_HEADERS, FLAG_END_HEADERS, 0, 0, 0, 1]); // partial
+        match scan_frames(&acc) {
+            FrameScan::NeedMore {
+                consumed,
+                send_settings_ack,
+            } => {
+                assert_eq!(consumed, 9, "the complete SETTINGS frame should be drained");
+                assert!(send_settings_ack);
+            }
+            _ => panic!("expected NeedMore after the complete SETTINGS frame"),
+        }
+    }
+
+    #[tokio::test]
+    async fn read_response_decodes_headers_over_duplex() {
+        let (mut server, mut client) = tokio::io::duplex(4096);
+        let mut frames = Vec::new();
+        put_frame(&mut frames, FRAME_SETTINGS, 0, 0, &[]);
+        put_frame(&mut frames, FRAME_HEADERS, FLAG_END_HEADERS, 1, &[0x88]);
+        server.write_all(&frames).await.unwrap();
+        let outcome = read_response(&mut client).await.unwrap();
+        assert!(outcome.responded);
+        assert_eq!(outcome.status, Some(200));
+    }
+
+    #[tokio::test]
+    async fn read_response_reset_on_eof() {
+        let (server, mut client) = tokio::io::duplex(64);
+        drop(server); // closing the peer makes the next read return 0 (EOF)
+        let outcome = read_response(&mut client).await.unwrap();
+        assert!(!outcome.responded);
+        assert!(outcome.reset);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,35 @@ async fn main() -> Result<()> {
         std::process::exit(2);
     }
 
+    // Validate `--checks` up front (target-independent): a typo must not
+    // silently scan nothing and report a clean target with exit 0.
+    if let Some(ref checks_str) = cli.checks {
+        let unknown =
+            smugglex::cli::unknown_check_names(checks_str, &smugglex::cli::KNOWN_CHECK_NAMES);
+        if !unknown.is_empty() && !is_machine() {
+            log(
+                LogLevel::Warning,
+                &format!(
+                    "ignoring unrecognized check name(s): {} (known: {})",
+                    unknown.join(", "),
+                    smugglex::cli::KNOWN_CHECK_NAMES.join(", "),
+                ),
+            );
+        }
+        if !smugglex::cli::has_any_known_check(checks_str, &smugglex::cli::KNOWN_CHECK_NAMES) {
+            emit_input_error(
+                &cli,
+                &format!(
+                    "no valid checks selected from --checks '{}'; nothing would be scanned (known checks: {})",
+                    checks_str,
+                    smugglex::cli::KNOWN_CHECK_NAMES.join(", "),
+                ),
+            );
+            // Usage/input error → exit 2
+            std::process::exit(2);
+        }
+    }
+
     // Collect outcomes from all targets. This enables:
     // - Clean single JSON document for batch scans (critical for AI / jq / scripts)
     // - Correct exit code (0 = clean, 1 = vulnerable found)

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -143,10 +143,13 @@ impl Mutator {
             {
                 let mutation_type = self.rand_index(4);
                 let new_val = match mutation_type {
-                    0 => format!("0{}", val),    // leading zero
-                    1 => format!("{}", val + 1), // off-by-one up
-                    2 => format!("{} ", val),    // trailing space
-                    3 => format!(" {}", val),    // leading space
+                    0 => format!("0{}", val), // leading zero
+                    // Saturating so a seed declaring `Content-Length: i64::MAX`
+                    // cannot overflow (a debug panic / release wrap to a negative
+                    // length); it simply stays at i64::MAX.
+                    1 => format!("{}", val.saturating_add(1)), // off-by-one up
+                    2 => format!("{} ", val),                  // trailing space
+                    3 => format!(" {}", val),                  // leading space
                     _ => format!("{}", val),
                 };
                 let value_start = after_header + skip_ws;
@@ -318,6 +321,29 @@ fn find_case_insensitive(haystack: &str, needle: &str) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mutate_cl_value_does_not_overflow_on_i64_max() {
+        // A seed declaring `Content-Length: i64::MAX` must not panic (debug
+        // overflow-checks) or wrap to a negative length when the off-by-one
+        // mutation fires. Drive mutate_cl_value across many PRNG states so the
+        // `val + 1` branch is exercised; previously this panicked on i64::MAX.
+        let seed = format!(
+            "POST / HTTP/1.1\r\nHost: h\r\nContent-Length: {}\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n",
+            i64::MAX
+        );
+        let mut m = Mutator::new(MutatorConfig {
+            seed: 1,
+            mutations_per_payload: 1,
+        });
+        for _ in 0..64 {
+            let mutated = m.mutate_cl_value(&seed);
+            assert!(
+                !mutated.contains("Content-Length: -"),
+                "off-by-one mutation must not produce a negative Content-Length"
+            );
+        }
+    }
 
     #[test]
     fn test_deterministic_output() {

--- a/src/output.rs
+++ b/src/output.rs
@@ -7,6 +7,38 @@ use crate::error::Result;
 use crate::model::{BatchScanResults, BatchSummary, CheckResult, FingerprintInfo, ScanResults};
 use crate::utils::{LogLevel, log};
 
+/// Atomically write `contents` to `path`: write to a sibling temp file, flush,
+/// then rename it over the destination. A failure during the write leaves any
+/// existing file at `path` untouched (the partial temp file is removed) instead
+/// of truncating a previously-valid report, which is what `File::create`
+/// followed by a failed `write_all` would do.
+fn atomic_write(path: &str, contents: &str) -> std::io::Result<()> {
+    let dest = std::path::Path::new(path);
+    let name = dest
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("smugglex-output");
+    // Temp file alongside the destination so the final rename stays on the same
+    // filesystem (a cross-device rename would fail). Tag with the PID to avoid
+    // clashing with any concurrent writer.
+    let tmp_name = format!(".{}.{}.tmp", name, std::process::id());
+    let tmp = match dest.parent().filter(|p| !p.as_os_str().is_empty()) {
+        Some(dir) => dir.join(tmp_name),
+        None => std::path::PathBuf::from(tmp_name),
+    };
+
+    let write = (|| {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(contents.as_bytes())?;
+        f.flush()
+    })();
+    if let Err(e) = write.and_then(|()| fs::rename(&tmp, dest)) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e);
+    }
+    Ok(())
+}
+
 /// Log scan results in the specified output format (plain text or JSON).
 pub fn log_scan_results(
     results: &[CheckResult],
@@ -125,8 +157,7 @@ pub fn save_results_to_file(
             &format!("overwriting existing file: {}", output_file),
         );
     }
-    let mut file = fs::File::create(output_file)?;
-    file.write_all(json_output.as_bytes())?;
+    atomic_write(output_file, &json_output)?;
     log(LogLevel::Info, &format!("results saved to {}", output_file));
     Ok(())
 }
@@ -185,11 +216,44 @@ pub fn save_batch_to_file(batch: &BatchScanResults, output_file: &str) -> crate:
             &format!("overwriting existing file: {}", output_file),
         );
     }
-    let mut file = fs::File::create(output_file)?;
-    file.write_all(json_output.as_bytes())?;
+    atomic_write(output_file, &json_output)?;
     log(
         LogLevel::Info,
         &format!("batch results saved to {}", output_file),
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atomic_write_overwrites_and_leaves_no_temp_file() {
+        let dir = std::env::temp_dir().join(format!("smugglex-atomic-{}", std::process::id()));
+        let _ = fs::create_dir_all(&dir);
+        let dest = dir.join("report.json");
+        let dest_str = dest.to_str().unwrap();
+
+        atomic_write(dest_str, "OLD").unwrap();
+        // Overwriting must leave a complete, valid final file (not a truncated one).
+        atomic_write(dest_str, "NEW-CONTENT").unwrap();
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "NEW-CONTENT");
+
+        // The sibling temp file must be renamed away, not left behind.
+        let leftover_tmp = fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().ends_with(".tmp"));
+        assert!(!leftover_tmp, "temp file should be renamed/removed");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn atomic_write_errors_on_unwritable_path() {
+        // Parent directory does not exist → error surfaced, nothing created.
+        let res = atomic_write("/nonexistent-smugglex-dir/sub/report.json", "DATA");
+        assert!(res.is_err());
+    }
 }

--- a/src/payloads/h2.rs
+++ b/src/payloads/h2.rs
@@ -114,19 +114,27 @@ pub fn get_h2_payloads(
         method, path, host, custom_header_str, cookie_str, host
     ));
 
-    // Multiple Content-Length headers (forbidden in HTTP/2 but might be forwarded)
+    // Multiple Content-Length headers (forbidden in HTTP/2 but might be forwarded).
+    // The second (larger) Content-Length must equal the smuggled request's byte
+    // length so a back-end that honors it consumes exactly the smuggled request
+    // and leaves the socket clean. A hardcoded length only matched a 10-char host.
+    let h2_dual_cl_smuggled = format!("GET /smuggled HTTP/1.1\r\nHost: {}\r\n\r\n", host);
     payloads.push(format!(
         "{} {} HTTP/1.1\r\n\
          Host: {}\r\n\
          {}\
          {}\
          Content-Length: 0\r\n\
-         Content-Length: 44\r\n\
+         Content-Length: {}\r\n\
          \r\n\
-         GET /smuggled HTTP/1.1\r\n\
-         Host: {}\r\n\
-         \r\n",
-        method, path, host, custom_header_str, cookie_str, host
+         {}",
+        method,
+        path,
+        host,
+        custom_header_str,
+        cookie_str,
+        h2_dual_cl_smuggled.len(),
+        h2_dual_cl_smuggled
     ));
 
     // === Header Value with Newline Attacks ===
@@ -373,7 +381,7 @@ pub fn get_h2_payloads(
          {}\
          {}\
          :authority: {}\r\n\
-         Content-Length: 10\r\n\
+         Content-Length: 8\r\n\
          Content-Length: 0\r\n\
          \r\n\
          smuggled",

--- a/src/raw_request.rs
+++ b/src/raw_request.rs
@@ -167,6 +167,15 @@ fn parse_origin_form(
         )
     })?;
     let (host, port) = split_host_port(&host_header)?;
+    // A present-but-empty Host (`Host:` or `Host:   `) leaves no connection
+    // target; rejecting it here fails fast with a clear message instead of a
+    // confusing downstream "URL parse error: empty host" against the synthetic
+    // connect URL.
+    if host.is_empty() {
+        return Err(SmugglexError::InvalidInput(
+            "raw request Host header is empty (required to determine the target)".to_string(),
+        ));
+    }
     Ok(RawRequest {
         method,
         target,
@@ -268,7 +277,14 @@ fn is_tchar(b: u8) -> bool {
 fn split_host_port(host_value: &str) -> Result<(String, Option<u16>)> {
     match host_value.rsplit_once(':') {
         Some((host, port))
-            if !host.is_empty() && !port.is_empty() && port.chars().all(|c| c.is_ascii_digit()) =>
+            if !host.is_empty()
+                && !port.is_empty()
+                && port.chars().all(|c| c.is_ascii_digit())
+                // Only split off a port when the host part is unambiguous: a
+                // bracketed IPv6 literal (`[::1]`) or a host with no embedded
+                // colon. An unbracketed IPv6 literal like `::1` would otherwise
+                // be mis-split into host ":" + port "1"; return it whole instead.
+                && (host.ends_with(']') || !host.contains(':')) =>
         {
             let parsed = port.parse::<u16>().map_err(|_| {
                 SmugglexError::InvalidInput(format!(
@@ -493,6 +509,38 @@ mod tests {
         let raw = "GET / HTTP/1.1\r\nAccept: */*\r\n\r\n";
         let err = parse_raw_request(raw).unwrap_err();
         assert!(matches!(err, SmugglexError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn errors_on_empty_host_header() {
+        // A present-but-empty (or whitespace-only) Host value must be rejected,
+        // not silently accepted as an empty connection host.
+        for raw in [
+            "GET / HTTP/1.1\r\nHost:\r\n\r\n",
+            "GET / HTTP/1.1\r\nHost:    \r\n\r\n",
+        ] {
+            let err = parse_raw_request(raw).unwrap_err();
+            assert!(
+                matches!(err, SmugglexError::InvalidInput(_)),
+                "empty Host should be InvalidInput, raw = {raw:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn split_host_port_does_not_split_unbracketed_ipv6() {
+        // `::1` is a malformed (unbracketed) IPv6 Host; it must NOT be mis-split
+        // into host ":" + port 1. Return the whole value with no port instead.
+        assert_eq!(split_host_port("::1").unwrap(), ("::1".to_string(), None));
+        assert_eq!(
+            split_host_port("fe80::1").unwrap(),
+            ("fe80::1".to_string(), None)
+        );
+        // Bracketed IPv6 with an explicit port still splits correctly.
+        assert_eq!(
+            split_host_port("[::1]:8080").unwrap(),
+            ("[::1]".to_string(), Some(8080))
+        );
     }
 
     #[test]

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -268,19 +268,41 @@ async fn measure_baseline(
     }
 
     let results = futures::future::join_all(futures).await;
+    aggregate_baseline(results)
+}
 
-    let mut durations = Vec::with_capacity(count);
-    let mut observed_status_codes = Vec::with_capacity(count);
+/// Aggregate the concurrent baseline probe results into a [`BaselineMeasurement`].
+///
+/// Failed probes (connection reset, timeout, EOF on a flaky network) are
+/// dropped rather than aborting the whole measurement — discarding the
+/// surviving samples over a single transient failure would turn an otherwise
+/// viable check into a false negative. Only when *every* probe failed is an
+/// error returned, since there is then nothing to measure against. This mirrors
+/// the best-effort behavior of `method_matched_baseline_durations`.
+fn aggregate_baseline(results: Vec<Result<(String, Duration)>>) -> Result<BaselineMeasurement> {
+    let mut durations = Vec::with_capacity(results.len());
+    let mut observed_status_codes = Vec::with_capacity(results.len());
     let mut last_status = String::new();
     let mut last_body_length = 0usize;
+    let mut last_error: Option<SmugglexError> = None;
 
     for result in results {
-        let (response, duration) = result?;
-        let status_line = response.lines().next().unwrap_or("");
-        observed_status_codes.push(parse_status_code(status_line));
-        durations.push(duration);
-        last_status = status_line.to_string();
-        last_body_length = response_body_length(&response);
+        match result {
+            Ok((response, duration)) => {
+                let status_line = response.lines().next().unwrap_or("");
+                observed_status_codes.push(parse_status_code(status_line));
+                durations.push(duration);
+                last_status = status_line.to_string();
+                last_body_length = response_body_length(&response);
+            }
+            Err(e) => last_error = Some(e),
+        }
+    }
+
+    if durations.is_empty() {
+        return Err(last_error.unwrap_or_else(|| {
+            SmugglexError::Io("baseline measurement produced no samples".into())
+        }));
     }
 
     let max_duration = durations.iter().copied().max().unwrap_or_default();
@@ -557,6 +579,24 @@ impl FollowupObservation {
     fn has_divergence(&self) -> bool {
         self.diverging > 0
     }
+
+    /// Whether the follow-up divergence is corroborated strongly enough to
+    /// override a control-based false-positive verdict. A single flaky probe —
+    /// one transient timeout or a lone status change — must NOT be enough, or a
+    /// uniformly slow backend (exactly the population the control check exists
+    /// to reject) gets promoted to a confirmed finding on one fluke. So the
+    /// main path requires a *majority* of the probes to diverge. The
+    /// unconditional second-request path already proves reproduction across two
+    /// independent plant+probe sequences, so a single divergence counts there
+    /// (it does not currently flow through the control FP check, but the guard
+    /// keeps the contract correct if it ever does).
+    fn has_corroborated_divergence(&self) -> bool {
+        if self.second_request {
+            self.diverging > 0
+        } else {
+            self.diverging * 2 > self.total
+        }
+    }
 }
 
 /// Send `FOLLOWUP_PROBE_COUNT` fresh-connection GET probes against the target
@@ -593,7 +633,10 @@ async fn observe_followup_divergence(
                 let status_line = response.lines().next().unwrap_or("");
                 let status_code = parse_status_code(status_line);
                 let body_len = response_body_length(&response);
-                let status_diverged = status_code != baseline.status_code;
+                // Use the structural status check (excludes flake-prone 5xx) so a
+                // transient gateway error does not count as desync divergence,
+                // matching `count_structural_followup_divergence`.
+                let status_diverged = followup_status_diverged(status_code, baseline.status_code);
                 let body_diverged = bodies_diverge(body_len, baseline.body_length);
                 if status_diverged || body_diverged {
                     diverging += 1;
@@ -748,11 +791,14 @@ fn control_indicates_false_positive(
     control: &ControlObservation,
     followup: Option<&FollowupObservation>,
 ) -> bool {
-    // ESCAPE: post-attack follow-up GET diverged from baseline → backend state
+    // ESCAPE: post-attack follow-up GETs diverged from baseline → backend state
     // was perturbed by the attack and persisted into a subsequent request.
     // This is the canonical "second-request" smuggling signature and overrides
-    // any timing/status FP rule.
-    if followup.is_some_and(|f| f.has_divergence()) {
+    // any timing/status FP rule — but only when *corroborated* (a majority of
+    // probes diverged). A single flaky follow-up (one transient timeout or a
+    // lone 5xx) must not override the control rejection, otherwise a uniformly
+    // slow backend is promoted to a finding on one fluke.
+    if followup.is_some_and(|f| f.has_corroborated_divergence()) {
         return false;
     }
 
@@ -1837,5 +1883,95 @@ mod tests {
         };
         // Both 504 would normally be FP, but body divergence overrides.
         assert!(!control_indicates_false_positive(&attack, &control, None));
+    }
+
+    #[test]
+    fn followup_single_flake_does_not_override_control_fp() {
+        // A uniformly-slow backend (control timing ~= attack) where exactly ONE
+        // of the 3 follow-up probes flaked. The control-FP rule must still fire:
+        // a single flaky follow-up is not corroboration.
+        let attack = VulnerabilityInfo {
+            status: "HTTP/1.1 200".into(),
+            status_code: Some(200),
+            duration: Duration::from_millis(2000),
+            body_length: 13,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        let control = ControlObservation {
+            duration: Duration::from_millis(1900), // very similar timing
+            status_code: Some(200),
+            body_length: 13,
+            header_fingerprint: ResponseHeaderFingerprint::default(),
+            is_connection_timeout: false,
+        };
+        let single_flake = FollowupObservation {
+            diverging: 1,
+            total: 3,
+            second_request: false,
+        };
+        assert!(
+            control_indicates_false_positive(&attack, &control, Some(&single_flake)),
+            "one flaky follow-up must not override the control rejection"
+        );
+    }
+
+    #[test]
+    fn has_corroborated_divergence_requires_majority_on_main_path() {
+        let one = FollowupObservation {
+            diverging: 1,
+            total: 3,
+            second_request: false,
+        };
+        let two = FollowupObservation {
+            diverging: 2,
+            total: 3,
+            second_request: false,
+        };
+        assert!(!one.has_corroborated_divergence(), "1/3 is not a majority");
+        assert!(two.has_corroborated_divergence(), "2/3 is a majority");
+        // The second-request path already reproduced across sequences, so a
+        // single divergence there is corroboration enough.
+        let second_req = FollowupObservation {
+            diverging: 1,
+            total: 3,
+            second_request: true,
+        };
+        assert!(second_req.has_corroborated_divergence());
+    }
+
+    #[test]
+    fn aggregate_baseline_tolerates_partial_probe_failure() {
+        // A single failed probe among successes must not discard the baseline.
+        let results: Vec<Result<(String, Duration)>> = vec![
+            Ok((
+                "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n".to_string(),
+                Duration::from_millis(100),
+            )),
+            Err(SmugglexError::Io("connection reset".into())),
+            Ok((
+                "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n".to_string(),
+                Duration::from_millis(120),
+            )),
+        ];
+        let baseline = aggregate_baseline(results).expect("survivors should yield a baseline");
+        assert_eq!(
+            baseline.observed_status_codes.len(),
+            2,
+            "only the successful probes contribute status codes"
+        );
+        assert_eq!(baseline.status_code, Some(200));
+    }
+
+    #[test]
+    fn aggregate_baseline_errors_only_when_all_probes_fail() {
+        let results: Vec<Result<(String, Duration)>> = vec![
+            Err(SmugglexError::Io("reset".into())),
+            Err(SmugglexError::Timeout("timed out".into())),
+        ];
+        assert!(
+            aggregate_baseline(results).is_err(),
+            "no surviving samples → error"
+        );
     }
 }

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -81,6 +81,38 @@ fn test_from_io_error() {
     }
 }
 
+/// A TimedOut io::Error must map to Timeout (with its actionable hint), not Io.
+#[test]
+fn test_from_io_error_timedout_maps_to_timeout() {
+    let io_err = io::Error::new(io::ErrorKind::TimedOut, "timed out");
+    let smugglex_err: SmugglexError = io_err.into();
+    assert!(
+        matches!(smugglex_err, SmugglexError::Timeout(_)),
+        "TimedOut io::Error should classify as Timeout"
+    );
+    assert!(smugglex_err.to_string().contains("try increasing timeout"));
+}
+
+/// tokio's Elapsed must convert to a Timeout variant.
+#[test]
+fn test_from_elapsed_maps_to_timeout() {
+    // Produce a real Elapsed by timing out an immediately-pending future.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .unwrap();
+    let elapsed: tokio::time::error::Elapsed = rt.block_on(async {
+        tokio::time::timeout(
+            std::time::Duration::from_millis(1),
+            std::future::pending::<()>(),
+        )
+        .await
+        .unwrap_err()
+    });
+    let smugglex_err: SmugglexError = elapsed.into();
+    assert!(matches!(smugglex_err, SmugglexError::Timeout(_)));
+}
+
 /// Test From<serde_json::Error> implementation
 #[test]
 fn test_from_serde_json_error() {

--- a/tests/http_tests.rs
+++ b/tests/http_tests.rs
@@ -202,3 +202,48 @@ async fn test_send_request_large_response() {
     assert!(response.contains("HTTP/1.1 200 OK"));
     assert!(response.contains(&large_body));
 }
+
+#[tokio::test]
+async fn test_pipeline_requests_preserves_responses_on_timeout() {
+    use smugglex::http::pipeline_requests;
+
+    let port = 8085;
+    // Server: answer the first request fully, then accept the second and never
+    // reply, forcing the pipelined exchange to stall until its own timeout.
+    tokio::spawn(async move {
+        let listener = TcpListener::bind(format!("127.0.0.1:{}", port))
+            .await
+            .unwrap();
+        if let Ok((mut socket, _)) = listener.accept().await {
+            let mut buf = [0u8; 1024];
+            let _ = socket.read(&mut buf).await.unwrap();
+            socket
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nAB")
+                .await
+                .unwrap();
+            // Second request: consumed but never answered.
+            let _ = socket.read(&mut buf).await.unwrap();
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        }
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let requests = vec![
+        "GET /a HTTP/1.1\r\nHost: localhost\r\n\r\n".to_string(),
+        "GET /b HTTP/1.1\r\nHost: localhost\r\n\r\n".to_string(),
+    ];
+    let responses = pipeline_requests("127.0.0.1", port, &requests, 1, false, false)
+        .await
+        .unwrap();
+
+    // The first response must survive even though the second request stalls past
+    // the timeout (previously the whole batch was discarded to an empty Vec).
+    assert_eq!(
+        responses.len(),
+        1,
+        "first response should survive the timeout"
+    );
+    assert!(responses[0].contains("HTTP/1.1 200 OK"));
+    assert!(responses[0].contains("AB"));
+}

--- a/tests/payloads_tests.rs
+++ b/tests/payloads_tests.rs
@@ -1117,6 +1117,36 @@ fn test_h2_content_length_conflicts() {
 }
 
 #[test]
+fn test_h2_dual_content_length_matches_smuggled_body_len() {
+    // The dual-Content-Length payload must declare a length equal to the
+    // smuggled request's byte length for ANY host. Previously it was hardcoded
+    // to 44, which only matched a 10-char host and mis-framed every other case.
+    for host in ["a.b", "test.com", "very-long-host.example.com"] {
+        let payloads = get_h2_payloads("/", host, "POST", &[], &[]);
+        let dual = payloads
+            .iter()
+            .find(|p| {
+                p.matches("Content-Length:").count() >= 2 && p.contains("GET /smuggled HTTP/1.1")
+            })
+            .expect("dual-Content-Length smuggling payload should exist");
+        let (head, body) = dual
+            .split_once("\r\n\r\n")
+            .expect("payload must have a header/body separator");
+        let declared: usize = head
+            .lines()
+            .filter_map(|l| l.strip_prefix("Content-Length: "))
+            .filter_map(|v| v.parse::<usize>().ok())
+            .find(|&n| n > 0)
+            .expect("a non-zero Content-Length should be declared");
+        assert_eq!(
+            declared,
+            body.len(),
+            "declared Content-Length must equal smuggled body length for host {host}"
+        );
+    }
+}
+
+#[test]
 fn test_h2_header_value_newline_injection() {
     let payloads = get_h2_payloads("/", "test.com", "GET", &[], &[]);
 

--- a/tests/utils_tests.rs
+++ b/tests/utils_tests.rs
@@ -215,3 +215,19 @@ fn test_parse_status_code_empty() {
 fn test_parse_status_code_partial() {
     assert_eq!(parse_status_code("HTTP/1.1"), None);
 }
+
+#[test]
+fn test_parse_status_code_overflow_returns_none() {
+    // A status number that overflows u16 (from a malicious/garbled server) must
+    // be rejected, not silently truncated, so it cannot feed a bogus code into
+    // detection comparisons.
+    assert_eq!(parse_status_code("HTTP/1.1 99999 Custom"), None);
+    assert_eq!(parse_status_code("HTTP/1.1 4294967296 X"), None);
+}
+
+#[test]
+fn test_parse_status_code_non_numeric_token_returns_none() {
+    // Valid protocol but a non-numeric status token → None.
+    assert_eq!(parse_status_code("HTTP/1.1 OK"), None);
+    assert_eq!(parse_status_code("HTTP/2 abc"), None);
+}


### PR DESCRIPTION
## Summary

An audit-driven hardening pass focused on **code stability** and **test coverage**. Findings came from an adversarially-verified per-subsystem audit; every fix ships with a regression test.

- **532 tests pass** (+34 new), `cargo clippy --all-targets --all-features -- -D warnings` clean, `rustfmt` clean
- End-to-end **Crystal lab: 18/18 scenarios pass** — incl. `FP_followup_503_overload` (validates the follow-up FP fix) and all TPs (`followup_divergence:3/3`, `second_request_desync`) still detect

## Stability / correctness fixes

| Area | Fix |
|---|---|
| `http.rs` | Checked `Content-Length` arithmetic in `read_one_http_response` — a near-`usize::MAX` header no longer overflows (debug panic) / truncates the response (release); mirrors `response_complete_len` |
| `http.rs` | `pipeline_requests` returns responses collected before a timeout instead of discarding them — restores response-queue capture on stalling follow-ups |
| `scanner.rs` | A single flaky follow-up (one transient 5xx/timeout) no longer overrides the control false-positive rejection; the escape now requires a **majority** of probes to diverge, and the main path excludes flake-prone 5xx |
| `scanner.rs` | A single failed baseline probe no longer aborts the whole check |
| `exploit/capture.rs` | A failed baseline GET no longer fabricates a "captured" smuggled response |
| `cli.rs`/`main.rs` | A typo'd `--checks` warns and **exits 2** instead of silently scanning nothing and reporting a clean target; `--timeout 0` rejected at parse time |
| `payloads/h2.rs` | Dual `Content-Length` matches the smuggled body length (was a hardcoded `44`, valid only for a 10-char host) |
| `raw_request.rs` | Reject an empty `Host` header; stop mis-splitting an unbracketed IPv6 literal (`::1`) into host `:` + port `1` |
| `mutator.rs` | Off-by-one `Content-Length` mutation uses `saturating_add` (was an `i64::MAX` overflow panic in debug) |
| `output.rs` | Atomic file writes (temp + rename) so a mid-write failure can't truncate a previously-valid report |
| `http2.rs` | Bound the frame parser with an explicit oversized-frame cap; guard `put_frame`'s 24-bit length field |

## Tests strengthened (+34, 498 → 532)

- Extracted a synchronous `scan_frames` helper to unit-test the HTTP/2 wire parser (terminal/partial/oversized frames) and `read_response` over a `tokio::io::duplex`
- Covered response framing/carry, the follow-up FP escape, baseline aggregation, TE.CL payload framing math, empty/IPv6 `Host`, status-code & error-conversion edges, and atomic writes

## Known follow-ups (deliberately out of scope)

- High-byte TE obfuscation patterns emit `U+FFFD` instead of the raw byte; a correct fix needs a `Vec<u8>` payload representation (the `String`-based `from_utf8_unchecked` workaround risks UB / invalid-UTF-8 JSON)
- Cross-signal confirmation counting (low, partially mitigated by the control check) and broader `main.rs` orchestration test coverage (needs extracting binary-private fns into the lib)