### PR TITLE
fix(tls): resolve #114/#115/#116 — provider verify schemes, config dedup, drop rustls-pemfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Second-request desync detection: when a CL.TE/TE.CL/TE.TE check finds no direct anomaly, smugglex now plants a TE payload and probes fresh follow-up requests for structural divergence (non-5xx status or body) from the baseline, reproduced across two independent plant+probe sequences. This catches "second-request" smuggling where the attack response itself is a clean `200` and only the *following* request on the shared upstream connection is corrupted — including the real socket-level lab in `lab/desync/`, which was previously missed by the `cl-te` check. Surfaced via the new `second_request_desync` detection signal.
 - Lab harness scenarios (`lab/validate.cr`): three stateful `TP_second_request_*` true positives and three new false positives (`FP_followup_503_overload`, `FP_te_request_405`, `FP_transient_404`) guarding the new probe against 5xx overload, attack-response status differences, and non-recurring transients.
 
+### Changed
+- Refactored the TLS configuration plumbing: the six near-identical per-protocol/per-mode builders collapse into a single `build_config` plus a shared `load_ca_roots`, and the HTTP/2 config is now built and cached once at init time so `--cacert` no longer re-reads and re-parses the CA file on every h2 probe. `--insecure` warns when `--cacert` is also supplied (since `-k` takes precedence), and the config getters fall back to a default config instead of panicking when TLS init is skipped (#115).
+- Replaced the archived `rustls-pemfile` crate with `rustls-pki-types`' built-in PEM parsing for `--cacert` (#116).
+
+### Fixed
+- `--insecure`/`-k` now advertises the active crypto provider's full set of signature schemes (including ECDSA P-521 and others previously omitted) instead of a hardcoded list, so servers presenting such certificates are reachable in insecure mode rather than failing the handshake before verification (#114).
+
 ## 0.3.0
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,15 +684,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,7 +781,7 @@ dependencies = [
  "futures",
  "indicatif",
  "rustls",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio-rustls = "0.26"
 rustls = "0.23"
-rustls-pemfile = "2"
+rustls-pki-types = "1"
 webpki-roots = "1.0"
 chrono = "0.4"
 futures = "0.3"

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,5 +1,6 @@
 use colored::*;
-use rustls::pki_types::ServerName;
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, ServerName};
 use std::path::Path;
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
@@ -10,8 +11,13 @@ use url::Url;
 
 use crate::error::{Result, SmugglexError};
 
-// Initializable TLS configuration
+// Cached TLS client configs, built once by `init_tls_config`. HTTP/1.1 and
+// HTTP/2 need separate configs because they advertise different ALPN protocols,
+// but they share the same trust policy. Caching the h2 config here (rather than
+// rebuilding it per probe) keeps `--cacert` from re-reading and re-parsing the
+// CA file from disk on every h2 connection.
 static TLS_CONFIG: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
+static H2_TLS_CONFIG: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
 
 /// A certificate verifier that accepts any certificate (for --insecure mode).
 #[derive(Debug)]
@@ -48,46 +54,33 @@ impl rustls::client::danger::ServerCertVerifier for PermitAnyCert {
     }
 
     fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        use rustls::SignatureScheme;
-        vec![
-            SignatureScheme::RSA_PKCS1_SHA256,
-            SignatureScheme::RSA_PKCS1_SHA384,
-            SignatureScheme::RSA_PKCS1_SHA512,
-            SignatureScheme::ECDSA_NISTP256_SHA256,
-            SignatureScheme::ECDSA_NISTP384_SHA384,
-            SignatureScheme::RSA_PSS_SHA256,
-            SignatureScheme::RSA_PSS_SHA384,
-            SignatureScheme::RSA_PSS_SHA512,
-            SignatureScheme::ED25519,
-        ]
+        // Delegate to the active crypto provider instead of hardcoding a list.
+        // rustls uses this both to build the `signature_algorithms` extension
+        // and to filter the server's `CertificateVerify` *before*
+        // `verify_tls1x_signature` runs. Any scheme missing here (e.g. ECDSA
+        // P-521 or Ed448) makes the handshake abort before this accept-anything
+        // verifier is ever consulted — leaving `--insecure` *less* compatible
+        // than normal mode. The provider is guaranteed to be installed by the
+        // time a handshake runs (building a `ClientConfig` installs the crate's
+        // default provider), so the empty fallback is unreachable in practice.
+        rustls::crypto::CryptoProvider::get_default()
+            .map(|p| p.signature_verification_algorithms.supported_schemes())
+            .unwrap_or_default()
     }
 }
 
-/// Build the default TLS config with webpki roots.
-fn build_default_tls_config() -> Arc<rustls::ClientConfig> {
+/// A fresh root store seeded with the bundled webpki trust anchors.
+fn webpki_root_store() -> rustls::RootCertStore {
     let mut root_store = rustls::RootCertStore::empty();
     root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-    Arc::new(
-        rustls::ClientConfig::builder()
-            .with_root_certificates(root_store)
-            .with_no_client_auth(),
-    )
+    root_store
 }
 
-/// Build an insecure TLS config that skips all certificate verification.
-fn build_insecure_tls_config() -> Arc<rustls::ClientConfig> {
-    Arc::new(
-        rustls::ClientConfig::builder()
-            .dangerous()
-            .with_custom_certificate_verifier(Arc::new(PermitAnyCert))
-            .with_no_client_auth(),
-    )
-}
-
-/// Build a TLS config with webpki roots plus a custom CA cert file.
-fn build_custom_ca_tls_config(ca_path: &Path) -> Result<Arc<rustls::ClientConfig>> {
-    let mut root_store = rustls::RootCertStore::empty();
-    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+/// Load CA certificates from a PEM file into a root store seeded with the
+/// webpki roots. PEM parsing goes through `rustls-pki-types`' own `pem`
+/// support, so no separate (archived) PEM crate is needed.
+fn load_ca_roots(ca_path: &Path) -> Result<rustls::RootCertStore> {
+    let mut root_store = webpki_root_store();
 
     let pem_data = std::fs::read(ca_path).map_err(|e| {
         SmugglexError::Io(format!(
@@ -96,8 +89,7 @@ fn build_custom_ca_tls_config(ca_path: &Path) -> Result<Arc<rustls::ClientConfig
             e
         ))
     })?;
-    let mut reader = std::io::BufReader::new(pem_data.as_slice());
-    let certs: Vec<rustls::pki_types::CertificateDer<'_>> = rustls_pemfile::certs(&mut reader)
+    let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(&pem_data)
         .collect::<std::result::Result<Vec<_>, _>>()
         .map_err(|e| SmugglexError::Tls(format!("failed to parse CA cert: {}", e)))?;
 
@@ -114,123 +106,78 @@ fn build_custom_ca_tls_config(ca_path: &Path) -> Result<Arc<rustls::ClientConfig
             .map_err(|e| SmugglexError::Tls(format!("failed to add CA cert: {}", e)))?;
     }
 
-    Ok(Arc::new(
+    Ok(root_store)
+}
+
+/// Build a single TLS client config for the given trust policy. `alpn_h2`
+/// advertises HTTP/2 (`h2`) via ALPN; the trust policy is otherwise identical
+/// between the HTTP/1.1 and HTTP/2 configs. This is the one builder that the six
+/// former per-protocol/per-mode builders collapse into.
+fn build_config(
+    insecure: bool,
+    ca_cert: Option<&Path>,
+    alpn_h2: bool,
+) -> Result<Arc<rustls::ClientConfig>> {
+    let mut config = if insecure {
+        rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(PermitAnyCert))
+            .with_no_client_auth()
+    } else {
+        let root_store = match ca_cert {
+            Some(ca_path) => load_ca_roots(ca_path)?,
+            None => webpki_root_store(),
+        };
         rustls::ClientConfig::builder()
             .with_root_certificates(root_store)
-            .with_no_client_auth(),
-    ))
+            .with_no_client_auth()
+    };
+    if alpn_h2 {
+        config.alpn_protocols = vec![b"h2".to_vec()];
+    }
+    Ok(Arc::new(config))
 }
 
 /// Initialize the global TLS configuration. Must be called once before any
 /// network requests. `insecure` disables certificate verification; `ca_cert`
-/// adds a custom CA certificate file (PEM) alongside webpki roots.
+/// adds a custom CA certificate file (PEM) alongside webpki roots. Both the
+/// HTTP/1.1 and HTTP/2 configs are built and cached here, so h2 probes never
+/// re-read the CA file from disk.
 pub fn init_tls_config(insecure: bool, ca_cert: Option<&Path>) -> Result<()> {
-    let config = if insecure {
-        build_insecure_tls_config()
-    } else if let Some(ca_path) = ca_cert {
-        build_custom_ca_tls_config(ca_path)?
-    } else {
-        build_default_tls_config()
-    };
+    if insecure && ca_cert.is_some() {
+        eprintln!(
+            "{} --insecure overrides --cacert; TLS certificate verification is disabled",
+            "[!]".yellow().bold()
+        );
+    }
+
+    let http1 = build_config(insecure, ca_cert, false)?;
+    let http2 = build_config(insecure, ca_cert, true)?;
 
     TLS_CONFIG
-        .set(config)
+        .set(http1)
         .map_err(|_| SmugglexError::Tls("TLS config already initialized".to_string()))?;
-
-    // Save settings so HTTP/2 can build its own config with the same policy.
-    let _ = TLS_SETTINGS.set(TlsInitSettings {
-        insecure,
-        ca_cert: ca_cert.map(|p| p.to_string_lossy().into_owned()),
-    });
+    // If TLS_CONFIG was fresh (the `?` above did not bail), this one is too.
+    let _ = H2_TLS_CONFIG.set(http2);
 
     Ok(())
 }
 
-/// Return a reference to the global TLS config (HTTP/1.1).
+/// Return the cached HTTP/1.1 TLS config. If `init_tls_config` was never called
+/// (library consumers, tests), fall back to a default webpki-roots config
+/// instead of panicking; the binary always inits first.
 pub fn get_tls_config() -> &'static Arc<rustls::ClientConfig> {
     TLS_CONFIG
-        .get()
-        .expect("TLS config not initialized — call init_tls_config first")
+        .get_or_init(|| build_config(false, None, false).expect("default TLS config is infallible"))
 }
 
-/// Settings captured at init time, reused by HTTP/2 to build its own config
-/// with the same trust policy but different ALPN.
-struct TlsInitSettings {
-    insecure: bool,
-    ca_cert: Option<String>,
-}
-
-static TLS_SETTINGS: OnceLock<TlsInitSettings> = OnceLock::new();
-
-/// Build an HTTP/2 TLS config (ALPN h2) matching the global trust policy.
-pub fn build_h2_tls_config() -> Result<Arc<rustls::ClientConfig>> {
-    let settings = TLS_SETTINGS
-        .get()
-        .expect("TLS settings not initialized — call init_tls_config first");
-
-    let config = if settings.insecure {
-        build_insecure_h2_tls_config()
-    } else if let Some(ref ca_path) = settings.ca_cert {
-        build_custom_ca_h2_tls_config(Path::new(ca_path))?
-    } else {
-        build_default_h2_tls_config()
-    };
-    Ok(config)
-}
-
-fn build_default_h2_tls_config() -> Arc<rustls::ClientConfig> {
-    let mut root_store = rustls::RootCertStore::empty();
-    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-    let mut cfg = rustls::ClientConfig::builder()
-        .with_root_certificates(root_store)
-        .with_no_client_auth();
-    cfg.alpn_protocols = vec![b"h2".to_vec()];
-    Arc::new(cfg)
-}
-
-fn build_insecure_h2_tls_config() -> Arc<rustls::ClientConfig> {
-    let mut cfg = rustls::ClientConfig::builder()
-        .dangerous()
-        .with_custom_certificate_verifier(Arc::new(PermitAnyCert))
-        .with_no_client_auth();
-    cfg.alpn_protocols = vec![b"h2".to_vec()];
-    Arc::new(cfg)
-}
-
-fn build_custom_ca_h2_tls_config(ca_path: &Path) -> Result<Arc<rustls::ClientConfig>> {
-    let mut root_store = rustls::RootCertStore::empty();
-    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-
-    let pem_data = std::fs::read(ca_path).map_err(|e| {
-        SmugglexError::Io(format!(
-            "failed to read CA cert file '{}': {}",
-            ca_path.display(),
-            e
-        ))
-    })?;
-    let mut reader = std::io::BufReader::new(pem_data.as_slice());
-    let certs: Vec<rustls::pki_types::CertificateDer<'_>> = rustls_pemfile::certs(&mut reader)
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|e| SmugglexError::Tls(format!("failed to parse CA cert: {}", e)))?;
-
-    if certs.is_empty() {
-        return Err(SmugglexError::Tls(format!(
-            "no certificates found in CA file '{}'",
-            ca_path.display()
-        )));
-    }
-
-    for cert in certs {
-        root_store
-            .add(cert)
-            .map_err(|e| SmugglexError::Tls(format!("failed to add CA cert: {}", e)))?;
-    }
-
-    let mut cfg = rustls::ClientConfig::builder()
-        .with_root_certificates(root_store)
-        .with_no_client_auth();
-    cfg.alpn_protocols = vec![b"h2".to_vec()];
-    Ok(Arc::new(cfg))
+/// Return the cached HTTP/2 TLS config (ALPN `h2`), mirroring `get_tls_config`.
+/// Built once at init time, so h2 probes reuse it rather than rebuilding (and,
+/// with `--cacert`, re-reading the CA file) on every connection.
+pub fn get_h2_tls_config() -> &'static Arc<rustls::ClientConfig> {
+    H2_TLS_CONFIG.get_or_init(|| {
+        build_config(false, None, true).expect("default h2 TLS config is infallible")
+    })
 }
 
 static PROXY: OnceLock<String> = OnceLock::new();
@@ -632,6 +579,117 @@ pub async fn send_request(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // A throwaway self-signed ECDSA P-256 certificate used only to exercise CA
+    // PEM parsing. It is not trusted for anything beyond these tests.
+    const TEST_CA_PEM: &str = "-----BEGIN CERTIFICATE-----\n\
+MIIBizCCATGgAwIBAgIUI+T8ON5AaiTHXj9NCrnmcjbX5w0wCgYIKoZIzj0EAwIw\n\
+GzEZMBcGA1UEAwwQc211Z2dsZXgtdGVzdC1jYTAeFw0yNjA3MDIwMjE3MTRaFw0z\n\
+NjA2MjkwMjE3MTRaMBsxGTAXBgNVBAMMEHNtdWdnbGV4LXRlc3QtY2EwWTATBgcq\n\
+hkjOPQIBBggqhkjOPQMBBwNCAAS3odwa9jb2EDMyxaSJK0x3K8ClDOaqVOhl/WSD\n\
+49cSDOAY/6YtsAfemTspMIlIF72/WKXC0OOaBA91F40D5lGko1MwUTAdBgNVHQ4E\n\
+FgQUkHsScQHXJRom6fCCYxOHzDg6nnEwHwYDVR0jBBgwFoAUkHsScQHXJRom6fCC\n\
+YxOHzDg6nnEwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiBxLwD7\n\
+b7gsdI1uCJNQ7DVc6fBAO6R+RC2GY54m3FBDTgIhAN4e51Gx9T9E3Z6zytX8bLCr\n\
+kJ8CRz+khnaPy0Io4PLR\n\
+-----END CERTIFICATE-----\n";
+
+    // Issue #114: the --insecure verifier must advertise the *provider's* full
+    // scheme set. rustls filters the server's CertificateVerify against this
+    // list before our accept-anything verifier is consulted, so any missing
+    // scheme (e.g. ECDSA P-521) makes such a server unreachable even with -k.
+    #[test]
+    fn permit_any_cert_advertises_provider_schemes_including_p521() {
+        use rustls::SignatureScheme;
+        use rustls::client::danger::ServerCertVerifier;
+        // Building any config installs the crate's default crypto provider, which
+        // `supported_verify_schemes` delegates to.
+        let _ = build_config(true, None, false).unwrap();
+        let schemes = PermitAnyCert.supported_verify_schemes();
+        assert!(
+            !schemes.is_empty(),
+            "verifier must advertise the provider's schemes, not an empty list"
+        );
+        // P-521 was missing from the old hardcoded list — the core of the bug.
+        assert!(
+            schemes.contains(&SignatureScheme::ECDSA_NISTP521_SHA512),
+            "P-521 must be advertised so --insecure can reach P-521 servers"
+        );
+        // Regression guard: previously-advertised schemes must remain.
+        assert!(schemes.contains(&SignatureScheme::ECDSA_NISTP256_SHA256));
+        assert!(schemes.contains(&SignatureScheme::ED25519));
+    }
+
+    // Issue #115: one builder for both protocols; only the h2 variant advertises
+    // ALPN `h2`, and the insecure variant needs no trust roots to build.
+    #[test]
+    fn build_config_sets_alpn_only_for_h2() {
+        let http1 = build_config(false, None, false).unwrap();
+        assert!(
+            http1.alpn_protocols.is_empty(),
+            "HTTP/1.1 config must not advertise h2"
+        );
+        let http2 = build_config(false, None, true).unwrap();
+        assert_eq!(
+            http2.alpn_protocols,
+            vec![b"h2".to_vec()],
+            "h2 config must advertise ALPN h2"
+        );
+        let insecure_h2 = build_config(true, None, true).unwrap();
+        assert_eq!(insecure_h2.alpn_protocols, vec![b"h2".to_vec()]);
+    }
+
+    // Issue #116: CA PEM parsing now goes through rustls-pki-types instead of the
+    // archived rustls-pemfile crate. Cover the success path plus the two error
+    // paths (missing file -> Io, no certs -> Tls).
+    #[test]
+    fn load_ca_roots_parses_pem_and_reports_errors() {
+        use std::io::Write;
+
+        let dir = std::env::temp_dir();
+        let pid = std::process::id();
+
+        // A valid cert is added on top of the webpki baseline.
+        let baseline = webpki_root_store().len();
+        let good = dir.join(format!("smugglex_ca_good_{pid}.pem"));
+        std::fs::File::create(&good)
+            .unwrap()
+            .write_all(TEST_CA_PEM.as_bytes())
+            .unwrap();
+        let roots = load_ca_roots(&good).expect("valid PEM cert should parse");
+        assert_eq!(
+            roots.len(),
+            baseline + 1,
+            "the custom CA must be added on top of the webpki roots"
+        );
+        let _ = std::fs::remove_file(&good);
+
+        // An empty PEM file yields a clear Tls "no certificates" error.
+        let empty = dir.join(format!("smugglex_ca_empty_{pid}.pem"));
+        std::fs::File::create(&empty).unwrap();
+        assert!(matches!(load_ca_roots(&empty), Err(SmugglexError::Tls(_))));
+        let _ = std::fs::remove_file(&empty);
+
+        // A missing file surfaces an Io error, distinct from a parse failure.
+        let missing = dir.join(format!("smugglex_ca_missing_{pid}.pem"));
+        let _ = std::fs::remove_file(&missing);
+        assert!(matches!(load_ca_roots(&missing), Err(SmugglexError::Io(_))));
+    }
+
+    // Issue #115 (item 3): the getters must not panic when init was skipped;
+    // they lazily fall back to a default config.
+    #[test]
+    fn tls_config_getters_fall_back_without_init() {
+        assert!(
+            get_tls_config().alpn_protocols.is_empty(),
+            "default HTTP/1.1 config advertises no ALPN"
+        );
+        assert_eq!(
+            get_h2_tls_config().alpn_protocols,
+            vec![b"h2".to_vec()],
+            "default h2 config advertises ALPN h2"
+        );
+    }
 
     #[test]
     fn find_subsequence_locates_header_terminator() {

--- a/src/http.rs
+++ b/src/http.rs
@@ -109,33 +109,49 @@ fn load_ca_roots(ca_path: &Path) -> Result<rustls::RootCertStore> {
     Ok(root_store)
 }
 
-/// Build a single TLS client config for the given trust policy. `alpn_h2`
+/// A resolved certificate-trust policy, computed once and shared by both the
+/// HTTP/1.1 and HTTP/2 configs. Resolving it here (rather than inside the
+/// per-protocol builder) means the `--cacert` file is read and PEM-parsed
+/// exactly once, not once per protocol.
+enum Trust {
+    /// Accept any certificate (`--insecure`).
+    AcceptAny,
+    /// Verify against these roots (webpki, optionally plus a custom CA).
+    Roots(rustls::RootCertStore),
+}
+
+/// Resolve the trust policy from the CLI flags. This is the only fallible,
+/// disk-touching step; it runs once per process.
+fn resolve_trust(insecure: bool, ca_cert: Option<&Path>) -> Result<Trust> {
+    if insecure {
+        return Ok(Trust::AcceptAny);
+    }
+    let roots = match ca_cert {
+        Some(ca_path) => load_ca_roots(ca_path)?,
+        None => webpki_root_store(),
+    };
+    Ok(Trust::Roots(roots))
+}
+
+/// Build a TLS client config from already-resolved trust material. `alpn_h2`
 /// advertises HTTP/2 (`h2`) via ALPN; the trust policy is otherwise identical
-/// between the HTTP/1.1 and HTTP/2 configs. This is the one builder that the six
-/// former per-protocol/per-mode builders collapse into.
-fn build_config(
-    insecure: bool,
-    ca_cert: Option<&Path>,
-    alpn_h2: bool,
-) -> Result<Arc<rustls::ClientConfig>> {
-    let mut config = if insecure {
-        rustls::ClientConfig::builder()
+/// between the HTTP/1.1 and HTTP/2 configs. Infallible — all fallible work
+/// happened in `resolve_trust`. This is the one builder that the six former
+/// per-protocol/per-mode builders collapse into.
+fn build_config(trust: &Trust, alpn_h2: bool) -> Arc<rustls::ClientConfig> {
+    let mut config = match trust {
+        Trust::AcceptAny => rustls::ClientConfig::builder()
             .dangerous()
             .with_custom_certificate_verifier(Arc::new(PermitAnyCert))
-            .with_no_client_auth()
-    } else {
-        let root_store = match ca_cert {
-            Some(ca_path) => load_ca_roots(ca_path)?,
-            None => webpki_root_store(),
-        };
-        rustls::ClientConfig::builder()
-            .with_root_certificates(root_store)
-            .with_no_client_auth()
+            .with_no_client_auth(),
+        Trust::Roots(roots) => rustls::ClientConfig::builder()
+            .with_root_certificates(roots.clone())
+            .with_no_client_auth(),
     };
     if alpn_h2 {
         config.alpn_protocols = vec![b"h2".to_vec()];
     }
-    Ok(Arc::new(config))
+    Arc::new(config)
 }
 
 /// Initialize the global TLS configuration. Must be called once before any
@@ -151,14 +167,24 @@ pub fn init_tls_config(insecure: bool, ca_cert: Option<&Path>) -> Result<()> {
         );
     }
 
-    let http1 = build_config(insecure, ca_cert, false)?;
-    let http2 = build_config(insecure, ca_cert, true)?;
+    // Resolve the trust policy once (reading/parsing `--cacert` a single time),
+    // then build both protocol configs from the same shared material.
+    let trust = resolve_trust(insecure, ca_cert)?;
+    let http1 = build_config(&trust, false);
+    let http2 = build_config(&trust, true);
 
+    // Commit both slots, surfacing a conflict from either. A conflict can only
+    // arise if a getter's `get_or_init` fallback already seeded a slot before
+    // init ran — i.e. init was called after the config was first used,
+    // violating the "init before any request" contract. Failing loudly there
+    // beats silently running with mismatched HTTP/1.1 and HTTP/2 trust policies
+    // (the two slots are independent `OnceLock`s, so they must be kept in sync).
     TLS_CONFIG
         .set(http1)
         .map_err(|_| SmugglexError::Tls("TLS config already initialized".to_string()))?;
-    // If TLS_CONFIG was fresh (the `?` above did not bail), this one is too.
-    let _ = H2_TLS_CONFIG.set(http2);
+    H2_TLS_CONFIG
+        .set(http2)
+        .map_err(|_| SmugglexError::Tls("TLS config already initialized".to_string()))?;
 
     Ok(())
 }
@@ -167,17 +193,14 @@ pub fn init_tls_config(insecure: bool, ca_cert: Option<&Path>) -> Result<()> {
 /// (library consumers, tests), fall back to a default webpki-roots config
 /// instead of panicking; the binary always inits first.
 pub fn get_tls_config() -> &'static Arc<rustls::ClientConfig> {
-    TLS_CONFIG
-        .get_or_init(|| build_config(false, None, false).expect("default TLS config is infallible"))
+    TLS_CONFIG.get_or_init(|| build_config(&Trust::Roots(webpki_root_store()), false))
 }
 
 /// Return the cached HTTP/2 TLS config (ALPN `h2`), mirroring `get_tls_config`.
 /// Built once at init time, so h2 probes reuse it rather than rebuilding (and,
 /// with `--cacert`, re-reading the CA file) on every connection.
 pub fn get_h2_tls_config() -> &'static Arc<rustls::ClientConfig> {
-    H2_TLS_CONFIG.get_or_init(|| {
-        build_config(false, None, true).expect("default h2 TLS config is infallible")
-    })
+    H2_TLS_CONFIG.get_or_init(|| build_config(&Trust::Roots(webpki_root_store()), true))
 }
 
 static PROXY: OnceLock<String> = OnceLock::new();
@@ -604,7 +627,7 @@ kJ8CRz+khnaPy0Io4PLR\n\
         use rustls::client::danger::ServerCertVerifier;
         // Building any config installs the crate's default crypto provider, which
         // `supported_verify_schemes` delegates to.
-        let _ = build_config(true, None, false).unwrap();
+        let _ = build_config(&Trust::AcceptAny, false);
         let schemes = PermitAnyCert.supported_verify_schemes();
         assert!(
             !schemes.is_empty(),
@@ -624,19 +647,55 @@ kJ8CRz+khnaPy0Io4PLR\n\
     // ALPN `h2`, and the insecure variant needs no trust roots to build.
     #[test]
     fn build_config_sets_alpn_only_for_h2() {
-        let http1 = build_config(false, None, false).unwrap();
+        let http1 = build_config(&Trust::Roots(webpki_root_store()), false);
         assert!(
             http1.alpn_protocols.is_empty(),
             "HTTP/1.1 config must not advertise h2"
         );
-        let http2 = build_config(false, None, true).unwrap();
+        let http2 = build_config(&Trust::Roots(webpki_root_store()), true);
         assert_eq!(
             http2.alpn_protocols,
             vec![b"h2".to_vec()],
             "h2 config must advertise ALPN h2"
         );
-        let insecure_h2 = build_config(true, None, true).unwrap();
+        let insecure_h2 = build_config(&Trust::AcceptAny, true);
         assert_eq!(insecure_h2.alpn_protocols, vec![b"h2".to_vec()]);
+    }
+
+    // Issue #115 (review follow-up): the trust policy is resolved once and both
+    // protocol configs are built from that single shared `Trust`, so the
+    // `--cacert` file is read and parsed exactly once instead of per protocol.
+    #[test]
+    fn resolve_trust_resolves_once_and_feeds_both_configs() {
+        use std::io::Write;
+
+        // --insecure => accept-any, no roots touched.
+        assert!(matches!(
+            resolve_trust(true, None).unwrap(),
+            Trust::AcceptAny
+        ));
+
+        // --cacert => a single resolved root store carrying the custom CA on top
+        // of the webpki baseline, reusable for both the h1 and h2 configs.
+        let dir = std::env::temp_dir();
+        let good = dir.join(format!("smugglex_trust_ca_{}.pem", std::process::id()));
+        std::fs::File::create(&good)
+            .unwrap()
+            .write_all(TEST_CA_PEM.as_bytes())
+            .unwrap();
+        let baseline = webpki_root_store().len();
+        let trust = resolve_trust(false, Some(&good)).unwrap();
+        let _ = std::fs::remove_file(&good);
+        match &trust {
+            Trust::Roots(roots) => assert_eq!(roots.len(), baseline + 1),
+            Trust::AcceptAny => panic!("expected Roots for --cacert"),
+        }
+        // The one resolved policy builds both protocol configs.
+        assert!(build_config(&trust, false).alpn_protocols.is_empty());
+        assert_eq!(
+            build_config(&trust, true).alpn_protocols,
+            vec![b"h2".to_vec()]
+        );
     }
 
     // Issue #116: CA PEM parsing now goes through rustls-pki-types instead of the

--- a/src/http2.rs
+++ b/src/http2.rs
@@ -186,8 +186,7 @@ fn status_from_indexed(byte: u8) -> Option<u16> {
 }
 
 async fn h2_connect(host: &str, port: u16) -> Result<tokio_rustls::client::TlsStream<TcpStream>> {
-    let cfg = crate::http::build_h2_tls_config()?;
-    let connector = TlsConnector::from(cfg);
+    let connector = TlsConnector::from(std::sync::Arc::clone(crate::http::get_h2_tls_config()));
     let tcp = TcpStream::connect((host, port)).await?;
     let dnsname = rustls::pki_types::ServerName::try_from(host.to_string())?;
     let tls = connector.connect(dnsname, tcp).await?;


### PR DESCRIPTION
## Summary

Resolves three follow-ups to PR #112, all in the TLS configuration plumbing (`src/http.rs` / `src/http2.rs`).

### #114 — `--insecure` advertised an incomplete set of signature schemes
`PermitAnyCert::supported_verify_schemes()` hardcoded a scheme list that omitted **ECDSA P-521** (and others). rustls filters the server's `CertificateVerify` against this list *before* the accept-anything verifier runs, so a P-521 server aborted the handshake even with `-k` — making insecure mode *less* compatible than normal mode. It now delegates to the active crypto provider's `signature_verification_algorithms.supported_schemes()`, keeping the advertised set in sync with what the provider can actually verify.

### #115 — TLS config refactor (the "code quality" ask)
- Collapsed the **six** near-identical per-protocol/per-mode builders into a single `build_config(insecure, ca_cert, alpn_h2)` plus a shared `load_ca_roots` / `webpki_root_store`.
- The **HTTP/2 config is now built and cached once** at `init_tls_config` time in its own `OnceLock`, instead of being rebuilt inside `h2_connect` on every probe. With `--cacert` this previously re-read and re-parsed the CA file from disk on each h2 connection (`run_h2_downgrade_check` issues many). The `TLS_SETTINGS` indirection is gone.
- Config getters now **fall back to a default config instead of panicking** when init is skipped (library consumers / tests).
- `init_tls_config` prints a one-line stderr warning when both `--insecure` and `--cacert` are given (`-k` wins, matching curl).

### #116 — drop archived `rustls-pemfile`
CA PEM parsing now uses `rustls-pki-types`' built-in `PemObject` support (`CertificateDer::pem_slice_iter`) instead of the archived `rustls-pemfile` crate. Note: `rustls-pki-types` 1.14.0 has no `pem` feature (as the issue suggested) — PEM parsing lives behind `alloc` (default), so the dependency is declared as `rustls-pki-types = "1"`.

## Tests
Added unit tests covering each fix:
- `permit_any_cert_advertises_provider_schemes_including_p521` — verifies the previously-missing P-521 scheme is now advertised (plus regression guards for P-256/Ed25519).
- `build_config_sets_alpn_only_for_h2` — ALPN `h2` set only for the h2 variant; insecure builds without trust roots.
- `load_ca_roots_parses_pem_and_reports_errors` — valid PEM parses onto the webpki baseline; empty file → `Tls`, missing file → `Io`.
- `tls_config_getters_fall_back_without_init` — getters no longer panic pre-init.

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and the full `cargo test` suite (172 lib + all integration tests) pass locally.

Closes #114
Closes #115
Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCF6gf2FDAqXPuHv4HJaTQ)_